### PR TITLE
Add java-features-reference module covering Java 8-25

### DIFF
--- a/java-features-reference/README.md
+++ b/java-features-reference/README.md
@@ -1,0 +1,153 @@
+# java-features-reference
+
+Interview-focused reference covering Java 8 through Java 25. Each Java version
+has its own package under `src/main/java/com/careerit/java/` with small,
+self-contained, runnable examples and Javadoc that call out the key talking
+points.
+
+## Prerequisites
+
+* Java 21 (parent `pom.xml` targets Java 21; the `java-features-reference`
+  module inherits that).
+* Maven 3.9+.
+
+Examples for Java 22-25 live under `futurejava/` as **reference-only** classes
+(feature summaries in Javadoc / comments). Compiling or running those features
+verbatim requires the corresponding JDK and, for previews, `--enable-preview`.
+
+## Build
+
+```bash
+mvn -pl java-features-reference -am compile
+```
+
+## Run a demo
+
+Every file has a `main(...)`. From the module directory:
+
+```bash
+mvn -pl java-features-reference exec:java \
+    -Dexec.mainClass=com.careerit.java.java08.StreamApi
+```
+
+Or from an IDE, right-click any file and run it.
+
+## Feature index
+
+### Java 8 (LTS, 2014)
+| File | Feature |
+| ---- | ------- |
+| `java08/LambdaExpressions.java` | Lambdas, capture rules, `this` in lambdas |
+| `java08/FunctionalInterfaces.java` | `Function`, `Predicate`, `Consumer`, `Supplier`, `UnaryOperator`, `BiFunction`, custom `@FunctionalInterface` |
+| `java08/MethodReferences.java` | All four kinds of method references |
+| `java08/StreamApi.java` | Streams, reductions, grouping, flatMap |
+| `java08/CollectorsDemo.java` | `groupingBy`, `partitioningBy`, `mapping`, `collectingAndThen` |
+| `java08/OptionalDemo.java` | Correct `Optional` usage |
+| `java08/DefaultStaticMethods.java` | Default + static methods on interfaces |
+| `java08/DateTimeApi.java` | `java.time` (Local/Zoned/Instant/Duration/Period) |
+| `java08/CompletableFutureDemo.java` | Async composition, `thenCompose`, `allOf`, error handling |
+
+### Java 9 (2017)
+| File | Feature |
+| ---- | ------- |
+| `java09/CollectionFactories.java` | `List.of`, `Set.of`, `Map.of`, `Map.ofEntries` |
+| `java09/StreamAndOptionalImprovements.java` | `takeWhile`, `dropWhile`, `iterate(3-arg)`, `Optional.ifPresentOrElse/or/stream` |
+| `java09/PrivateInterfaceMethods.java` | `private` methods on interfaces (+ JPMS notes) |
+
+### Java 10 (2018)
+| File | Feature |
+| ---- | ------- |
+| `java10/VarLocalInference.java` | `var` local variables, rules and gotchas |
+
+### Java 11 (LTS, 2018)
+| File | Feature |
+| ---- | ------- |
+| `java11/StringMethods.java` | `isBlank`, `strip`, `lines`, `repeat` |
+| `java11/VarInLambda.java` | `var` in lambda parameters |
+| `java11/HttpClientDemo.java` | Standardized `java.net.http.HttpClient` |
+| `java11/FilesReadWriteString.java` | `Files.readString` / `Files.writeString` |
+
+### Java 12 (2019)
+| File | Feature |
+| ---- | ------- |
+| `java12/SwitchExpressionsPreview.java` | Switch expressions, arrow labels, `yield` |
+| `java12/CollectorsTeeing.java` | `Collectors.teeing` for two-in-one reductions |
+
+### Java 13 (2019)
+| File | Feature |
+| ---- | ------- |
+| `java13/TextBlocksPreview.java` | Text blocks, incidental whitespace, `\s`, `\<newline>` |
+
+### Java 14 (2020)
+| File | Feature |
+| ---- | ------- |
+| `java14/RecordsPreview.java` | Records (compact ctor, validation, factories) |
+| `java14/PatternMatchingInstanceof.java` | Pattern matching for `instanceof` |
+| `java14/HelpfulNpe.java` | Helpful NullPointerExceptions |
+
+### Java 15 (2020)
+| File | Feature |
+| ---- | ------- |
+| `java15/SealedClassesPreview.java` | Sealed interfaces + exhaustive switch |
+| `java15/TextBlocksFinal.java` | Text blocks are permanent |
+
+### Java 16 (2021)
+| File | Feature |
+| ---- | ------- |
+| `java16/RecordsFinalized.java` | Records standard; local records/enums/interfaces |
+| `java16/StreamToList.java` | `Stream.toList()` |
+
+### Java 17 (LTS, 2021)
+| File | Feature |
+| ---- | ------- |
+| `java17/SealedFinal.java` | Sealed classes permanent; `non-sealed` |
+| `java17/PatternMatchingSwitchPreview.java` | Switch patterns, `case null`, guards |
+| `java17/RandomGenerators.java` | Enhanced pseudo-random generators |
+
+### Java 18 (2022)
+| File | Feature |
+| ---- | ------- |
+| `java18/Utf8ByDefault.java` | UTF-8 is the default charset (JEP 400) |
+
+### Java 19 (2022)
+| File | Feature |
+| ---- | ------- |
+| `java19/VirtualThreadsPreview.java` | Virtual threads preview |
+| `java19/RecordPatternsPreview.java` | Record deconstruction patterns |
+| `java19/StructuredConcurrencyIncubator.java` | Structured concurrency notes |
+
+### Java 20 (2023)
+| File | Feature |
+| ---- | ------- |
+| `java20/ScopedValuesIncubator.java` | Scoped values + re-previews overview |
+
+### Java 21 (LTS, 2023)
+| File | Feature |
+| ---- | ------- |
+| `java21/VirtualThreadsFinal.java` | Virtual threads standard |
+| `java21/SequencedCollections.java` | `SequencedCollection/Set/Map` |
+| `java21/PatternMatchingSwitchFinal.java` | Switch patterns + record patterns final |
+| `java21/StringTemplatesPreview.java` | String templates (preview) |
+| `java21/ScopedValuesPreview.java` | Scoped values (preview) |
+| `java21/UnnamedPatternsPreview.java` | Unnamed variables `_` (preview) |
+
+### Future (reference notes only)
+
+Under `com.careerit.java.futurejava`:
+
+| File | Target version |
+| ---- | -------------- |
+| `Java22Features.java` | Unnamed vars/patterns final, FFM final, Stream Gatherers, Statements before super, Structured Concurrency, Class-File API |
+| `Java23Features.java` | Markdown Javadoc, Module Imports, Primitive Patterns, Flexible Constructor Bodies |
+| `Java24Features.java` | Stream Gatherers permanent, Virtual threads without pinning, Scoped Values stabilizing |
+| `Java25Features.java` | LTS: Scoped Values final, Module Imports final, Compact Source Files + instance `main`, Flexible Constructor Bodies final |
+
+## Interview prep tips
+
+* Know **why** each feature was added (pain point it solves), not just syntax.
+* Have one go-to example per feature you can write on a whiteboard.
+* Expect follow-ups: e.g. "Stream.parallel() - when would you avoid it?",
+  "Why does Optional.get() get flagged by linters?", "Virtual threads vs.
+  reactive - pick one and justify."
+* The `futurejava/*` Javadocs double as a LTS-upgrade checklist when
+  consulting on Java 21 -> 25 migrations.

--- a/java-features-reference/README.md
+++ b/java-features-reference/README.md
@@ -1,9 +1,12 @@
 # java-features-reference
 
-Interview-focused reference covering Java 8 through Java 25. Each Java version
-has its own package under `src/main/java/com/careerit/java/` with small,
-self-contained, runnable examples and Javadoc that call out the key talking
-points.
+Interview-focused reference covering **Java 8 through Java 25**. Each Java
+version has its own package under `src/main/java/com/careerit/java/` with
+small, self-contained, runnable examples and Javadoc that call out the key
+talking points.
+
+**Start here:** [`STUDY_GUIDE.md`](./STUDY_GUIDE.md) - a week-by-week learning
+path with prompts to answer before reading each file.
 
 ## Prerequisites
 
@@ -37,12 +40,15 @@ Or from an IDE, right-click any file and run it.
 ### Java 8 (LTS, 2014)
 | File | Feature |
 | ---- | ------- |
-| `java08/LambdaExpressions.java` | Lambdas, capture rules, `this` in lambdas |
+| `java08/LambdaExpressions.java` | Lambdas, capture rules, `this` in lambdas, comparator chaining, function composition |
 | `java08/FunctionalInterfaces.java` | `Function`, `Predicate`, `Consumer`, `Supplier`, `UnaryOperator`, `BiFunction`, custom `@FunctionalInterface` |
 | `java08/MethodReferences.java` | All four kinds of method references |
-| `java08/StreamApi.java` | Streams, reductions, grouping, flatMap |
+| `java08/StreamApi.java` | Streams deep-dive: filter/map/reduce, groupingBy, partitioningBy, short-circuiting, flatMap, peek, iterate, "consumed once" rule |
+| `java08/StreamAdvanced.java` | 10 real interview patterns (top customer, dedupe by field, group anagrams, etc.) |
+| `java08/ParallelStreams.java` | When parallel helps, when it hurts, shared state traps |
 | `java08/CollectorsDemo.java` | `groupingBy`, `partitioningBy`, `mapping`, `collectingAndThen` |
-| `java08/OptionalDemo.java` | Correct `Optional` usage |
+| `java08/OptionalDemo.java` | Correct `Optional` usage, anti-patterns, orElse vs orElseGet |
+| `java08/LambdaExceptionHandling.java` | Checked exceptions inside lambdas / streams |
 | `java08/DefaultStaticMethods.java` | Default + static methods on interfaces |
 | `java08/DateTimeApi.java` | `java.time` (Local/Zoned/Instant/Duration/Period) |
 | `java08/CompletableFutureDemo.java` | Async composition, `thenCompose`, `allOf`, error handling |
@@ -130,6 +136,14 @@ Or from an IDE, right-click any file and run it.
 | `java21/StringTemplatesPreview.java` | String templates (preview) |
 | `java21/ScopedValuesPreview.java` | Scoped values (preview) |
 | `java21/UnnamedPatternsPreview.java` | Unnamed variables `_` (preview) |
+
+### Cross-cutting interview patterns
+| File | Content |
+| ---- | ------- |
+| `interviewpatterns/ClassicProblems.java` | 11 classic problems (second-highest salary, char frequency, palindrome, Fibonacci, anagrams, FizzBuzz, ...) solved with modern Java |
+| `interviewpatterns/FunctionalPatterns.java` | Memoization, strategy map, Function.andThen pipeline, "with*" updates on records, higher-order functions, currying |
+| `interviewpatterns/ConcurrencyBasics.java` | Executors, Future, CompletableFuture composition, timeouts, atomic vs synchronized, virtual threads |
+| `interviewpatterns/BeforeAfterJava8.java` | Side-by-side old Java vs modern Java for the same tasks |
 
 ### Future (reference notes only)
 

--- a/java-features-reference/STUDY_GUIDE.md
+++ b/java-features-reference/STUDY_GUIDE.md
@@ -1,0 +1,142 @@
+# STUDY GUIDE - How to use this repo
+
+This guide turns the examples into a **learning path**. Each step tells you
+which files to read, what to focus on, and a question to answer BEFORE you
+read the code.
+
+> Golden rule: try to predict the output first, then run, then explain to
+> yourself in one sentence why you were right or wrong.
+
+---
+
+## How to run any example
+
+```bash
+# from repo root
+mvn -pl java-features-reference -am compile
+
+# run any file that has a main(...)
+mvn -pl java-features-reference exec:java \
+    -Dexec.mainClass=com.careerit.java.java08.StreamApi
+```
+
+In IntelliJ / VS Code, just click the green arrow next to `main`.
+
+---
+
+## Week 1 - Java 8 foundations (most important for interviews)
+
+| Day | Files | Prompt to answer first |
+| --- | ----- | ---------------------- |
+| 1 | `java08/LambdaExpressions.java`, `java08/FunctionalInterfaces.java` | "What does 'effectively final' mean and why do lambdas require it?" |
+| 2 | `java08/MethodReferences.java`, `java08/DefaultStaticMethods.java` | "Name the 4 kinds of method references." |
+| 3 | `java08/StreamApi.java` | "What is a terminal operation, and why does a stream 'run' only after one?" |
+| 4 | `java08/CollectorsDemo.java`, `java08/StreamAdvanced.java` | "What's the difference between `toMap` with and without a merge function?" |
+| 5 | `java08/OptionalDemo.java`, `java08/LambdaExceptionHandling.java` | "When would you use `orElseGet` over `orElse`?" |
+| 6 | `java08/DateTimeApi.java`, `java08/CompletableFutureDemo.java` | "When do you pick `Instant` vs `ZonedDateTime`?" |
+| 7 | `java08/ParallelStreams.java`, `interviewpatterns/BeforeAfterJava8.java` | "Name two situations where a parallel stream is a bad idea." |
+
+At the end of week 1 you should be able to solve any classic collection
+manipulation problem (group by, count, top N, dedupe, partition) with streams.
+
+---
+
+## Week 2 - Modern Java (9 to 17)
+
+| Day | Files | Prompt |
+| --- | ----- | ------ |
+| 8  | `java09/*`, `java10/VarLocalInference.java` | "When should you NOT use `var`?" |
+| 9  | `java11/*` | "What changed about the default String trim behaviour in Java 11?" |
+| 10 | `java12/*`, `java13/*` | "What does `yield` do in a switch expression?" |
+| 11 | `java14/*` | "Why are records implicitly final?" |
+| 12 | `java15/*`, `java16/*` | "What are the three modifiers allowed on a subtype of a sealed class?" |
+| 13 | `java17/SealedFinal.java`, `java17/PatternMatchingSwitchPreview.java` | "How does pattern matching enable exhaustive switches?" |
+| 14 | `java17/RandomGenerators.java` + revise | "What's the difference between `findFirst` and `findAny`?" |
+
+---
+
+## Week 3 - Current LTS features and concurrency
+
+| Day | Files | Prompt |
+| --- | ----- | ------ |
+| 15 | `java18/*`, `java19/VirtualThreadsPreview.java` | "Why are virtual threads mostly useful for IO-bound work?" |
+| 16 | `java19/RecordPatternsPreview.java`, `java20/*` | "Write a switch over a sealed type using record patterns." |
+| 17 | `java21/VirtualThreadsFinal.java`, `java21/SequencedCollections.java` | "Name 3 existing collection types that are now `SequencedCollection`." |
+| 18 | `java21/PatternMatchingSwitchFinal.java` | "How do guarded patterns interact with exhaustiveness?" |
+| 19 | `interviewpatterns/ConcurrencyBasics.java` | "When would you prefer `thenCompose` over `thenApply`?" |
+| 20 | `interviewpatterns/FunctionalPatterns.java` | "How would you implement memoization of a pure function?" |
+| 21 | `interviewpatterns/ClassicProblems.java` | Solve any 5 without looking, from scratch. |
+
+---
+
+## Week 4 - Lookahead and polish
+
+* Skim `futurejava/Java22Features.java` ... `Java25Features.java` for the LTS
+  roadmap. These are reference notes, not runnable features (require JDK 22+).
+* Re-run every example WITHOUT looking at the code; write a 1-line summary
+  next to each `System.out.println(...)` output.
+* Practice the prompts in the "Interview questions bank" below.
+
+---
+
+## Interview questions bank
+
+**Lambdas / functional interfaces**
+1. What is a functional interface? Name 6 from `java.util.function`.
+2. Difference between `Function<T,R>` and `UnaryOperator<T>`?
+3. What does `effectively final` mean?
+4. Why can you use `this` inside a lambda to reach the enclosing class?
+5. How would you convert a method that throws a checked exception into a `Function`?
+
+**Streams**
+6. Lazy vs eager evaluation - what's the distinction?
+7. Difference between `map` and `flatMap`.
+8. Why is `Stream.peek` "debug only"?
+9. Give three short-circuiting operations.
+10. Why is `parallelStream()` not always faster?
+11. Difference between `reduce(identity, op)` and `reduce(op)`.
+12. What happens if you call two terminal operations on the same stream?
+
+**Collectors**
+13. `groupingBy` vs `partitioningBy`.
+14. How do you avoid `IllegalStateException` from `toMap` with duplicate keys?
+15. What does `Collectors.teeing` solve?
+
+**Optional**
+16. When should you NOT return `Optional`?
+17. Difference between `orElse` and `orElseGet`.
+18. `Optional.get()` - when is it safe?
+
+**Records**
+19. What does the compiler generate for a record?
+20. Why can't records have additional instance fields?
+21. What is a compact constructor? What can you do inside it?
+
+**Sealed / pattern matching**
+22. What are the three modifiers allowed on a sealed subtype?
+23. Why does pattern matching over a sealed type not require a `default`?
+24. Show a switch that uses a guard `when` clause.
+
+**Concurrency**
+25. `Future.get()` vs `CompletableFuture.get()` - name two differences.
+26. `thenApply` vs `thenCompose` vs `thenCombine` - when to use each?
+27. What is a virtual thread, and when is it the right choice?
+28. What problem do `SequencedCollection` methods solve?
+
+**Date/Time**
+29. Why is `Instant` preferred to `java.util.Date` for storing timestamps?
+30. `Period` vs `Duration`.
+
+---
+
+## Tips for live interviews
+
+* **Narrate your thinking.** Interviewers grade reasoning, not keystrokes.
+* **Prefer clarity over cleverness.** A short for-loop is better than a wrong
+  stream. Upgrade to a stream once the logic is right.
+* **Name one pitfall per feature.** "Virtual threads are great for IO, but
+  before Java 24 synchronized blocks could pin the carrier" - that level of
+  detail earns points.
+* **When stuck, fall back to types.** Ask "what type do I have, what type do
+  I want, which transformation gets me there?" That narrows `map` vs `flatMap`
+  vs `reduce` automatically.

--- a/java-features-reference/pom.xml
+++ b/java-features-reference/pom.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.careerit</groupId>
+        <artifactId>jfs</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>java-features-reference</artifactId>
+    <name>java-features-reference</name>
+    <description>Interview-ready reference covering Java 8 through Java 25 features</description>
+
+    <properties>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
+    </properties>
+
+</project>

--- a/java-features-reference/src/main/java/com/careerit/java/futurejava/Java22Features.java
+++ b/java-features-reference/src/main/java/com/careerit/java/futurejava/Java22Features.java
@@ -1,0 +1,57 @@
+package com.careerit.java.futurejava;
+
+/**
+ * Java 22 - Reference notes (requires JDK 22+ to compile).
+ *
+ * Permanent features:
+ *   JEP 456 - Unnamed Variables and Patterns
+ *     for (Point _ : pts) { ... }
+ *     (x, _) -> x
+ *     catch (IOException _) { ... }
+ *
+ *   JEP 454 - Foreign Function and Memory API
+ *     Replaces JNI for calling native code:
+ *       try (Arena a = Arena.ofConfined()) {
+ *           MemorySegment cString = a.allocateUtf8String("hello");
+ *           Linker linker = Linker.nativeLinker();
+ *           MethodHandle strlen = linker.downcallHandle(
+ *               linker.defaultLookup().find("strlen").orElseThrow(),
+ *               FunctionDescriptor.of(JAVA_LONG, ADDRESS));
+ *           long n = (long) strlen.invoke(cString);
+ *       }
+ *
+ * Preview / incubating in 22:
+ *   JEP 447 - Statements before super(...) / this(...) in constructors
+ *     class Sub extends Base {
+ *         Sub(int x) {
+ *             if (x < 0) throw new IllegalArgumentException();
+ *             super(x * 2);
+ *         }
+ *     }
+ *
+ *   JEP 461 - Stream Gatherers
+ *     Stream.gather(...) - pluggable intermediate operations, similar to how
+ *     Collectors plugs into terminal operations.
+ *     Example: a sliding-window gatherer
+ *       stream.gather(Gatherers.windowSliding(3)).forEach(System.out::println);
+ *
+ *   JEP 462 - Structured Concurrency (2nd preview)
+ *     try (var scope = new StructuredTaskScope.ShutdownOnFailure()) {
+ *         Subtask<String> a = scope.fork(() -> fetchA());
+ *         Subtask<String> b = scope.fork(() -> fetchB());
+ *         scope.join().throwIfFailed();
+ *         return a.get() + b.get();
+ *     }
+ *
+ *   JEP 459 - String Templates (second preview; later withdrawn).
+ *   JEP 457 - Class-File API (preview).
+ *   JEP 464 - Scoped Values (second preview).
+ *   JEP 463 - Implicitly declared classes / instance main methods (2nd preview).
+ *
+ * This file is a placeholder for interview notes only.
+ */
+public class Java22Features {
+    public static void main(String[] args) {
+        System.out.println("Java 22 reference notes - see source comments.");
+    }
+}

--- a/java-features-reference/src/main/java/com/careerit/java/futurejava/Java23Features.java
+++ b/java-features-reference/src/main/java/com/careerit/java/futurejava/Java23Features.java
@@ -1,0 +1,37 @@
+package com.careerit.java.futurejava;
+
+/**
+ * Java 23 - Reference notes (requires JDK 23+ to compile).
+ *
+ * Standard:
+ *   JEP 467 - Markdown Documentation Comments
+ *     Javadoc comments can now use Markdown:
+ *       /// # Heading
+ *       /// - bullet
+ *       /// code: `example`
+ *
+ * Preview / Second previews:
+ *   JEP 476 - Module Import Declarations
+ *     `import module java.sql;` imports everything the module exports.
+ *
+ *   JEP 455 - Primitive Types in Patterns, instanceof, switch
+ *     if (obj instanceof int i) { ... }      // unboxing pattern
+ *     switch (obj) { case int i -> ...; case long l -> ...; }
+ *
+ *   JEP 482 - Flexible Constructor Bodies (renamed from JEP 447)
+ *     Lets validation/preparation statements appear before super(...).
+ *
+ *   JEP 469 - Vector API (8th incubator).
+ *   JEP 473 - Stream Gatherers (2nd preview).
+ *   JEP 480 - Structured Concurrency (3rd preview).
+ *   JEP 481 - Scoped Values (3rd preview).
+ *   JEP 477 - Implicitly Declared Classes and Instance Main Methods (3rd preview).
+ *
+ * Notable removal:
+ *   JEP 471 - Deprecate the Memory-Access Methods in sun.misc.Unsafe.
+ */
+public class Java23Features {
+    public static void main(String[] args) {
+        System.out.println("Java 23 reference notes - see source comments.");
+    }
+}

--- a/java-features-reference/src/main/java/com/careerit/java/futurejava/Java24Features.java
+++ b/java-features-reference/src/main/java/com/careerit/java/futurejava/Java24Features.java
@@ -1,0 +1,33 @@
+package com.careerit.java.futurejava;
+
+/**
+ * Java 24 - Reference notes (requires JDK 24+ to compile).
+ *
+ * Standard:
+ *   JEP 485 - Stream Gatherers
+ *     Permanent API for pluggable intermediate stream ops:
+ *       var windowed = nums.stream().gather(Gatherers.windowFixed(3)).toList();
+ *       var dedup    = nums.stream().gather(Gatherers.fold(...)).toList();
+ *
+ *   JEP 487 - Scoped Values (still preview as of 24 but stable API shape).
+ *   JEP 491 - Synchronize Virtual Threads Without Pinning
+ *     `synchronized` blocks no longer pin virtual threads to their carrier,
+ *     removing a major virtual-thread footgun.
+ *
+ * Preview:
+ *   JEP 488 - Primitive Types in Patterns, instanceof, switch (2nd preview).
+ *   JEP 492 - Flexible Constructor Bodies (3rd preview).
+ *   JEP 494 - Module Import Declarations (2nd preview).
+ *   JEP 495 - Simple Source Files and Instance Main Methods (4th preview).
+ *   JEP 499 - Structured Concurrency (4th preview).
+ *
+ * Security:
+ *   JEP 493 - Linking Run-Time Images without JMODs.
+ *   JEP 484 - Class-File API promoted.
+ *   JEP 486 - Permanently Disable the Security Manager.
+ */
+public class Java24Features {
+    public static void main(String[] args) {
+        System.out.println("Java 24 reference notes - see source comments.");
+    }
+}

--- a/java-features-reference/src/main/java/com/careerit/java/futurejava/Java25Features.java
+++ b/java-features-reference/src/main/java/com/careerit/java/futurejava/Java25Features.java
@@ -1,0 +1,40 @@
+package com.careerit.java.futurejava;
+
+/**
+ * Java 25 - Reference notes (LTS; requires JDK 25+ to compile).
+ *
+ * Java 25 is the next Long-Term Support (LTS) release after Java 21 and
+ * rolls up the preview features that have been baking for several cycles.
+ *
+ * Permanent features:
+ *   JEP 506 - Scoped Values
+ *     Final form of ScopedValue.where(KEY, v).run(...).
+ *
+ *   JEP 511 - Module Import Declarations
+ *     `import module java.sql;` now standard.
+ *
+ *   JEP 512 - Compact Source Files and Instance Main Methods
+ *     Minimal program:
+ *       void main() {
+ *           IO.println("hi");
+ *       }
+ *     No class, no String[] args, no static. Ideal for teaching / scripts.
+ *
+ *   JEP 513 - Flexible Constructor Bodies
+ *     Validation/prep statements before super(...) / this(...) are permanent.
+ *
+ *   JEP 519 - Compact Object Headers (production).
+ *
+ * Preview:
+ *   JEP 507 - Primitive Types in Patterns, instanceof, switch (3rd preview).
+ *   JEP 505 - Structured Concurrency (5th preview).
+ *   JEP 502 - Stable Values (1st preview): lazy, one-shot, final-like values.
+ *
+ * Deprecations / removals:
+ *   JEP 503 - Remove the 32-bit x86 port.
+ */
+public class Java25Features {
+    public static void main(String[] args) {
+        System.out.println("Java 25 reference notes - see source comments.");
+    }
+}

--- a/java-features-reference/src/main/java/com/careerit/java/interviewpatterns/BeforeAfterJava8.java
+++ b/java-features-reference/src/main/java/com/careerit/java/interviewpatterns/BeforeAfterJava8.java
@@ -1,0 +1,155 @@
+package com.careerit.java.interviewpatterns;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * ============================================================================
+ *  BEFORE/AFTER - how modern Java shortens everyday code
+ * ============================================================================
+ *
+ *  A favorite interview question: "Show me how you would do X in Java 7 vs.
+ *  how you would do it today." Each block below has the pre-Java 8 version
+ *  and the modern version so you can see the delta.
+ * ============================================================================
+ */
+public class BeforeAfterJava8 {
+
+    record Person(String name, int age) {}
+
+    public static void main(String[] args) {
+
+        List<Person> people = List.of(
+                new Person("Ravi", 30),
+                new Person("Asha", 35),
+                new Person("Kiran", 28),
+                new Person("Mira", 40));
+
+        // ---------------------------------------------------------------
+        // 1. Sort by age
+        // ---------------------------------------------------------------
+        List<Person> copy1 = new ArrayList<>(people);
+        //  BEFORE
+        Collections.sort(copy1, new Comparator<Person>() {
+            @Override public int compare(Person a, Person b) { return a.age() - b.age(); }
+        });
+        //  AFTER
+        List<Person> copy2 = new ArrayList<>(people);
+        copy2.sort(Comparator.comparingInt(Person::age));
+
+        System.out.println("[1] sorted = " + copy2);
+
+        // ---------------------------------------------------------------
+        // 2. Filter adults and collect names
+        // ---------------------------------------------------------------
+        //  BEFORE
+        List<String> namesBefore = new ArrayList<>();
+        for (Person p : people) {
+            if (p.age() >= 30) namesBefore.add(p.name());
+        }
+
+        //  AFTER
+        List<String> namesAfter = people.stream()
+                .filter(p -> p.age() >= 30)
+                .map(Person::name)
+                .collect(Collectors.toList());
+        System.out.println("[2] before = " + namesBefore);
+        System.out.println("[2] after  = " + namesAfter);
+
+        // ---------------------------------------------------------------
+        // 3. Build a map name -> age
+        // ---------------------------------------------------------------
+        //  BEFORE
+        Map<String, Integer> ageByNameBefore = new HashMap<>();
+        for (Person p : people) ageByNameBefore.put(p.name(), p.age());
+
+        //  AFTER
+        Map<String, Integer> ageByNameAfter = people.stream()
+                .collect(Collectors.toMap(Person::name, Person::age));
+        System.out.println("[3] after = " + ageByNameAfter);
+
+        // ---------------------------------------------------------------
+        // 4. Remove duplicates while preserving order
+        // ---------------------------------------------------------------
+        List<String> raw = List.of("a", "b", "a", "c", "b", "d");
+
+        //  BEFORE
+        List<String> distinctBefore = new ArrayList<>();
+        for (String s : raw) if (!distinctBefore.contains(s)) distinctBefore.add(s);
+
+        //  AFTER
+        List<String> distinctAfter = raw.stream().distinct().collect(Collectors.toList());
+        System.out.println("[4] distinct = " + distinctAfter);
+
+        // ---------------------------------------------------------------
+        // 5. Group by age bucket (under 30 / 30+)
+        // ---------------------------------------------------------------
+        //  BEFORE
+        Map<String, List<Person>> byBucketBefore = new HashMap<>();
+        for (Person p : people) {
+            String key = p.age() < 30 ? "young" : "older";
+            byBucketBefore.computeIfAbsent(key, k -> new ArrayList<>()).add(p);
+        }
+
+        //  AFTER
+        Map<String, List<Person>> byBucketAfter = people.stream()
+                .collect(Collectors.groupingBy(p -> p.age() < 30 ? "young" : "older"));
+        System.out.println("[5] after = " + byBucketAfter);
+
+        // ---------------------------------------------------------------
+        // 6. Iterate and remove (in-place)
+        // ---------------------------------------------------------------
+        //  BEFORE
+        List<Integer> nums = new ArrayList<>(List.of(1, 2, 3, 4, 5, 6));
+        for (Iterator<Integer> it = nums.iterator(); it.hasNext(); ) {
+            if (it.next() % 2 == 0) it.remove();
+        }
+
+        //  AFTER - removeIf (Java 8)
+        List<Integer> nums2 = new ArrayList<>(List.of(1, 2, 3, 4, 5, 6));
+        nums2.removeIf(n -> n % 2 == 0);
+
+        System.out.println("[6] before=" + nums + " after=" + nums2);
+
+        // ---------------------------------------------------------------
+        // 7. Try-with-resources (Java 7) vs explicit close (Java 6)
+        // ---------------------------------------------------------------
+        // Java 7+:
+        //   try (var reader = Files.newBufferedReader(path)) { ... }
+        // Resources are closed automatically, in reverse order.
+        System.out.println("[7] use try-with-resources for AutoCloseable");
+
+        // ---------------------------------------------------------------
+        // 8. Null-safe chaining - Optional vs manual null checks
+        // ---------------------------------------------------------------
+        record Address(String city) {}
+        record User(String name, Address address) {}
+
+        User userA = new User("Ravi", new Address("Hyderabad"));
+        User userB = new User("Asha", null);
+
+        //  BEFORE - deep null checks
+        String cityBefore;
+        if (userB != null && userB.address() != null && userB.address().city() != null) {
+            cityBefore = userB.address().city();
+        } else {
+            cityBefore = "unknown";
+        }
+
+        //  AFTER - Optional chain
+        String cityAfter = java.util.Optional.ofNullable(userB)
+                .map(User::address)
+                .map(Address::city)
+                .orElse("unknown");
+
+        System.out.println("[8] before=" + cityBefore + " after=" + cityAfter);
+        System.out.println("[8] userA city = " + java.util.Optional.ofNullable(userA)
+                .map(User::address).map(Address::city).orElse("unknown"));
+    }
+}

--- a/java-features-reference/src/main/java/com/careerit/java/interviewpatterns/ClassicProblems.java
+++ b/java-features-reference/src/main/java/com/careerit/java/interviewpatterns/ClassicProblems.java
@@ -1,0 +1,146 @@
+package com.careerit.java.interviewpatterns;
+
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+/**
+ * ============================================================================
+ *  CLASSIC INTERVIEW PROBLEMS - solved with modern Java (8+)
+ * ============================================================================
+ *
+ *  These are the problems that come up again and again. Each has a tiny,
+ *  idiomatic solution using streams, records, pattern matching, etc.
+ *
+ *  Try to solve each one by hand BEFORE looking at the implementation.
+ * ============================================================================
+ */
+public class ClassicProblems {
+
+    public static void main(String[] args) {
+
+        // ---------------------------------------------------------------
+        // 1. Find the second-highest salary
+        // ---------------------------------------------------------------
+        int[] salaries = {50, 90, 70, 90, 80};
+        int secondHighest = Arrays.stream(salaries)
+                .distinct()
+                .boxed()
+                .sorted((a, b) -> b - a)
+                .skip(1)
+                .findFirst()
+                .orElseThrow();
+        System.out.println("[1] second highest = " + secondHighest);
+
+        // ---------------------------------------------------------------
+        // 2. Frequency of each character in a string (order-preserving)
+        // ---------------------------------------------------------------
+        String word = "programming";
+        Map<Character, Long> freq = word.chars()
+                .mapToObj(c -> (char) c)
+                .collect(Collectors.groupingBy(
+                        c -> c, LinkedHashMap::new, Collectors.counting()));
+        System.out.println("[2] freq = " + freq);
+
+        // ---------------------------------------------------------------
+        // 3. First non-repeated character
+        // ---------------------------------------------------------------
+        Character firstNonRepeated = freq.entrySet().stream()
+                .filter(e -> e.getValue() == 1)
+                .map(Map.Entry::getKey)
+                .findFirst()
+                .orElse(null);
+        System.out.println("[3] first non-repeated in '" + word + "' = " + firstNonRepeated);
+
+        // ---------------------------------------------------------------
+        // 4. Sum of digits of a number
+        // ---------------------------------------------------------------
+        int n = 12345;
+        int sumOfDigits = String.valueOf(n).chars().map(c -> c - '0').sum();
+        System.out.println("[4] sum of digits of " + n + " = " + sumOfDigits);
+
+        // ---------------------------------------------------------------
+        // 5. Reverse each word of a sentence
+        // ---------------------------------------------------------------
+        String sentence = "java is fun";
+        String reversedWords = Arrays.stream(sentence.split(" "))
+                .map(w -> new StringBuilder(w).reverse().toString())
+                .collect(Collectors.joining(" "));
+        System.out.println("[5] reversed words = " + reversedWords);
+
+        // ---------------------------------------------------------------
+        // 6. Palindrome check (stream-free AND stream versions)
+        // ---------------------------------------------------------------
+        String s = "racecar";
+        boolean palindromeClassic = new StringBuilder(s).reverse().toString().equals(s);
+        boolean palindromeStream  = IntStream.range(0, s.length() / 2)
+                .allMatch(i -> s.charAt(i) == s.charAt(s.length() - 1 - i));
+        System.out.println("[6] palindrome? classic=" + palindromeClassic + ", stream=" + palindromeStream);
+
+        // ---------------------------------------------------------------
+        // 7. Fibonacci sequence of length 10 using Stream.iterate
+        // ---------------------------------------------------------------
+        List<Integer> fib = java.util.stream.Stream.iterate(new int[]{0, 1},
+                        arr -> new int[]{arr[1], arr[0] + arr[1]})
+                .limit(10)
+                .map(arr -> arr[0])
+                .collect(Collectors.toList());
+        System.out.println("[7] fibonacci = " + fib);
+
+        // ---------------------------------------------------------------
+        // 8. Find duplicates in a list
+        // ---------------------------------------------------------------
+        List<Integer> data = List.of(1, 2, 3, 2, 4, 5, 3, 6);
+        List<Integer> duplicates = data.stream()
+                .collect(Collectors.groupingBy(x -> x, Collectors.counting()))
+                .entrySet().stream()
+                .filter(e -> e.getValue() > 1)
+                .map(Map.Entry::getKey)
+                .collect(Collectors.toList());
+        System.out.println("[8] duplicates = " + duplicates);
+
+        // ---------------------------------------------------------------
+        // 9. Group anagrams
+        // ---------------------------------------------------------------
+        List<String> words = List.of("eat", "tea", "tan", "ate", "nat", "bat");
+        Map<String, List<String>> anagrams = words.stream()
+                .collect(Collectors.groupingBy(ClassicProblems::sortChars));
+        System.out.println("[9] anagram groups = " + anagrams.values());
+
+        // ---------------------------------------------------------------
+        // 10. Max occurring element
+        // ---------------------------------------------------------------
+        Integer mostFrequent = data.stream()
+                .collect(Collectors.groupingBy(x -> x, Collectors.counting()))
+                .entrySet().stream()
+                .max(Map.Entry.comparingByValue())
+                .map(Map.Entry::getKey)
+                .orElseThrow();
+        System.out.println("[10] most frequent = " + mostFrequent);
+
+        // ---------------------------------------------------------------
+        // 11. FizzBuzz using switch expression
+        // ---------------------------------------------------------------
+        IntStream.rangeClosed(1, 15).forEach(i -> System.out.print(fizzbuzz(i) + " "));
+        System.out.println();
+    }
+
+    private static String sortChars(String s) {
+        char[] ch = s.toCharArray();
+        Arrays.sort(ch);
+        return new String(ch);
+    }
+
+    private static String fizzbuzz(int i) {
+        int key = (i % 3 == 0 ? 1 : 0) + (i % 5 == 0 ? 2 : 0);
+        return switch (key) {
+            case 1  -> "Fizz";
+            case 2  -> "Buzz";
+            case 3  -> "FizzBuzz";
+            default -> String.valueOf(i);
+        };
+    }
+}

--- a/java-features-reference/src/main/java/com/careerit/java/interviewpatterns/ConcurrencyBasics.java
+++ b/java-features-reference/src/main/java/com/careerit/java/interviewpatterns/ConcurrencyBasics.java
@@ -1,0 +1,116 @@
+package com.careerit.java.interviewpatterns;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * ============================================================================
+ *  CONCURRENCY BASICS you'll face in interviews
+ * ============================================================================
+ *
+ *   1. ExecutorService + Future vs. CompletableFuture
+ *   2. Composing async work (thenCombine, thenCompose)
+ *   3. Timeout + fallback
+ *   4. Atomic counters vs synchronized
+ *   5. Virtual threads (Java 21) for many IO-bound tasks
+ *
+ *  Always shut down your executors. Use try-with-resources for
+ *  ExecutorService (available on Java 19+: AutoCloseable).
+ * ============================================================================
+ */
+public class ConcurrencyBasics {
+
+    public static void main(String[] args) throws Exception {
+
+        // ---------------------------------------------------------------
+        // 1. Basic ExecutorService + Future
+        // ---------------------------------------------------------------
+        try (ExecutorService pool = Executors.newFixedThreadPool(4)) {
+            var futures = List.of(
+                    pool.submit(() -> slowSquare(2)),
+                    pool.submit(() -> slowSquare(3)),
+                    pool.submit(() -> slowSquare(4)));
+            int sum = 0;
+            for (var f : futures) sum += f.get();
+            System.out.println("[1] sum of squares = " + sum);
+        }
+
+        // ---------------------------------------------------------------
+        // 2. Compose async results without blocking
+        // ---------------------------------------------------------------
+        CompletableFuture<String> user  = CompletableFuture.supplyAsync(() -> "Ravi");
+        CompletableFuture<Integer> age  = CompletableFuture.supplyAsync(() -> 30);
+
+        String greet = user.thenCombine(age, (u, a) -> u + " (" + a + ")").get();
+        System.out.println("[2] greet = " + greet);
+
+        // thenCompose: when the next step also returns a CompletableFuture
+        CompletableFuture<Integer> profileAge = CompletableFuture
+                .supplyAsync(() -> "user-42")
+                .thenCompose(ConcurrencyBasics::fetchAgeAsync);
+        System.out.println("[2] age = " + profileAge.get());
+
+        // ---------------------------------------------------------------
+        // 3. Timeout + fallback
+        // ---------------------------------------------------------------
+        CompletableFuture<String> slow = CompletableFuture.supplyAsync(() -> {
+            sleep(500);
+            return "slow-value";
+        });
+        String withFallback = slow
+                .completeOnTimeout("timeout-default", 100, TimeUnit.MILLISECONDS)
+                .get();
+        System.out.println("[3] with timeout = " + withFallback);
+
+        // ---------------------------------------------------------------
+        // 4. Atomic counters vs synchronized
+        // ---------------------------------------------------------------
+        AtomicLong atomic = new AtomicLong();
+        long[] shared   = {0};
+        Object lock     = new Object();
+
+        Runnable atomicInc  = () -> { for (int i=0;i<100_000;i++) atomic.incrementAndGet(); };
+        Runnable syncInc    = () -> { for (int i=0;i<100_000;i++) synchronized (lock) { shared[0]++; } };
+
+        var t1 = new Thread(atomicInc);  var t2 = new Thread(atomicInc);
+        t1.start(); t2.start(); t1.join(); t2.join();
+
+        var t3 = new Thread(syncInc);    var t4 = new Thread(syncInc);
+        t3.start(); t4.start(); t3.join(); t4.join();
+
+        System.out.println("[4] atomic      = " + atomic.get());
+        System.out.println("[4] synchronized= " + shared[0]);
+
+        // ---------------------------------------------------------------
+        // 5. Virtual threads (Java 21) - scale to many IO-bound tasks cheaply
+        // ---------------------------------------------------------------
+        long t0 = System.currentTimeMillis();
+        try (var vt = Executors.newVirtualThreadPerTaskExecutor()) {
+            for (int i = 0; i < 1000; i++) {
+                vt.submit(() -> { sleep(20); return null; });
+            }
+        } // close() waits for all tasks to finish
+        System.out.println("[5] 1000 IO-bound vt tasks done in " +
+                (System.currentTimeMillis() - t0) + "ms");
+    }
+
+    private static int slowSquare(int n) {
+        sleep(100);
+        return n * n;
+    }
+
+    private static CompletableFuture<Integer> fetchAgeAsync(String userId) {
+        return CompletableFuture.supplyAsync(() -> {
+            sleep(50);
+            return userId.length() + 20;
+        });
+    }
+
+    private static void sleep(long ms) {
+        try { Thread.sleep(ms); } catch (InterruptedException ie) { Thread.currentThread().interrupt(); }
+    }
+}

--- a/java-features-reference/src/main/java/com/careerit/java/interviewpatterns/FunctionalPatterns.java
+++ b/java-features-reference/src/main/java/com/careerit/java/interviewpatterns/FunctionalPatterns.java
@@ -1,0 +1,121 @@
+package com.careerit.java.interviewpatterns;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+/**
+ * ============================================================================
+ *  FUNCTIONAL-STYLE PATTERNS used in real Java codebases
+ * ============================================================================
+ *
+ *   1. Memoization with computeIfAbsent
+ *   2. Strategy map (replace if/else-if ladders)
+ *   3. Pipeline with Function.andThen
+ *   4. Builder-free "with*" style on records
+ *   5. Higher-order functions: functions that return functions
+ *   6. Currying
+ *   7. Filtering with composed predicates
+ * ============================================================================
+ */
+public class FunctionalPatterns {
+
+    public static void main(String[] args) {
+
+        // ---------------------------------------------------------------
+        // 1. Memoization using computeIfAbsent + a closure
+        // ---------------------------------------------------------------
+        Map<Integer, Long> cache = new ConcurrentHashMap<>();
+        Function<Integer, Long> slowSquare = n -> {
+            try { Thread.sleep(50); } catch (InterruptedException ignored) {}
+            return (long) n * n;
+        };
+        Function<Integer, Long> memoized = n -> cache.computeIfAbsent(n, slowSquare);
+
+        long t = System.currentTimeMillis();
+        memoized.apply(7); memoized.apply(7); memoized.apply(7);
+        System.out.println("[1] 3 calls took " + (System.currentTimeMillis() - t) + "ms (cached)");
+
+        // ---------------------------------------------------------------
+        // 2. Strategy map - replace a chain of if/else-if
+        // ---------------------------------------------------------------
+        Map<String, Function<Double, Double>> taxRules = Map.of(
+                "standard", amt -> amt * 0.18,
+                "reduced",  amt -> amt * 0.05,
+                "zero",     amt -> 0.0);
+
+        double tax = taxRules.getOrDefault("reduced", a -> a * 0.18).apply(1000.0);
+        System.out.println("[2] tax = " + tax);
+
+        // ---------------------------------------------------------------
+        // 3. Building a processing pipeline with Function.andThen
+        // ---------------------------------------------------------------
+        Function<String, String> trim     = String::trim;
+        Function<String, String> toLower  = String::toLowerCase;
+        Function<String, String> dashes   = s -> s.replace(' ', '-');
+
+        Function<String, String> slugify = trim.andThen(toLower).andThen(dashes);
+        System.out.println("[3] slug = " + slugify.apply("  Hello World  "));
+
+        // ---------------------------------------------------------------
+        // 4. Builder-free "with*" updaters on records (copy-and-mutate)
+        // ---------------------------------------------------------------
+        record Person(String name, int age, String city) {
+            Person withAge(int a)       { return new Person(name, a, city); }
+            Person withCity(String c)   { return new Person(name, age, c); }
+        }
+
+        Person p = new Person("Ravi", 30, "Hyderabad");
+        Person older = p.withAge(31);
+        Person moved = older.withCity("Bengaluru");
+        System.out.println("[4] " + moved);
+
+        // ---------------------------------------------------------------
+        // 5. Higher-order function: function that RETURNS a function
+        // ---------------------------------------------------------------
+        Function<Integer, Function<Integer, Integer>> adder = x -> y -> x + y;
+        Function<Integer, Integer> add10 = adder.apply(10);
+        System.out.println("[5] add10(5) = " + add10.apply(5));
+
+        // ---------------------------------------------------------------
+        // 6. Currying: turn f(a, b, c) into f(a)(b)(c)
+        // ---------------------------------------------------------------
+        Function<Double, Function<Double, Function<Double, Double>>> pricer =
+                base -> taxRate -> discount -> base * (1 + taxRate) * (1 - discount);
+
+        double finalPrice = pricer.apply(1000.0).apply(0.18).apply(0.10);
+        System.out.println("[6] finalPrice = " + finalPrice);
+
+        // ---------------------------------------------------------------
+        // 7. Filtering with composed predicates
+        // ---------------------------------------------------------------
+        record Employee(String name, String dept, double salary) {}
+        List<Employee> emps = List.of(
+                new Employee("Ravi",  "ENG", 90_000),
+                new Employee("Asha",  "ENG", 120_000),
+                new Employee("Kiran", "HR",  60_000),
+                new Employee("Mira",  "HR",  75_000));
+
+        Predicate<Employee> isEng        = e -> e.dept().equals("ENG");
+        Predicate<Employee> earnsAlot    = e -> e.salary() > 100_000;
+        Predicate<Employee> seniorEng    = isEng.and(earnsAlot);
+        Predicate<Employee> nonEngs      = isEng.negate();
+
+        System.out.println("[7] senior-eng = " +
+                emps.stream().filter(seniorEng).map(Employee::name).collect(Collectors.toList()));
+        System.out.println("[7] non-engs   = " +
+                emps.stream().filter(nonEngs).map(Employee::name).collect(Collectors.toList()));
+
+        // Optional chaining as a safer null-handling pipeline
+        String uppercased = Optional.of("  hello  ")
+                .map(String::trim)
+                .filter(x -> !x.isBlank())
+                .map(String::toUpperCase)
+                .orElse("EMPTY");
+        System.out.println("[7] uppercased = " + uppercased);
+    }
+}

--- a/java-features-reference/src/main/java/com/careerit/java/java08/CollectorsDemo.java
+++ b/java-features-reference/src/main/java/com/careerit/java/java08/CollectorsDemo.java
@@ -1,0 +1,57 @@
+package com.careerit.java.java08;
+
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.stream.Collectors;
+
+/**
+ * Java 8 - Collectors cheat sheet.
+ *
+ *   toList / toSet / toMap
+ *   joining(delim, prefix, suffix)
+ *   counting / summingInt / averagingDouble
+ *   groupingBy(classifier, downstream)
+ *   partitioningBy(predicate)
+ *   mapping / reducing / collectingAndThen
+ */
+public class CollectorsDemo {
+
+    record Txn(String user, String type, double amount) {}
+
+    public static void main(String[] args) {
+        List<Txn> txns = List.of(
+                new Txn("ravi",  "credit", 100),
+                new Txn("ravi",  "debit",   40),
+                new Txn("asha",  "credit", 250),
+                new Txn("asha",  "debit",   20),
+                new Txn("kiran", "credit",  10));
+
+        String joined = txns.stream().map(Txn::user).distinct()
+                .collect(Collectors.joining(", ", "[", "]"));
+        System.out.println("users = " + joined);
+
+        Map<String, Double> totalByUser = txns.stream()
+                .collect(Collectors.groupingBy(Txn::user, Collectors.summingDouble(Txn::amount)));
+        System.out.println("totalByUser = " + totalByUser);
+
+        Map<Boolean, Long> creditVsDebit = txns.stream()
+                .collect(Collectors.partitioningBy(t -> t.type().equals("credit"), Collectors.counting()));
+        System.out.println("creditVsDebit = " + creditVsDebit);
+
+        Map<String, List<Double>> amountsByUser = txns.stream()
+                .collect(Collectors.groupingBy(Txn::user,
+                        Collectors.mapping(Txn::amount, Collectors.toList())));
+        System.out.println("amountsByUser = " + amountsByUser);
+
+        TreeMap<String, Long> sortedCount = txns.stream()
+                .collect(Collectors.groupingBy(Txn::user, TreeMap::new, Collectors.counting()));
+        System.out.println("sortedCount = " + sortedCount);
+
+        List<String> users = txns.stream()
+                .map(Txn::user)
+                .distinct()
+                .collect(Collectors.collectingAndThen(Collectors.toList(), List::copyOf));
+        System.out.println("immutable users = " + users);
+    }
+}

--- a/java-features-reference/src/main/java/com/careerit/java/java08/CompletableFutureDemo.java
+++ b/java-features-reference/src/main/java/com/careerit/java/java08/CompletableFutureDemo.java
@@ -1,0 +1,59 @@
+package com.careerit.java.java08;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+
+/**
+ * Java 8 - CompletableFuture.
+ *
+ * Async + composable alternative to Future. Supports chaining with
+ * thenApply / thenCompose / thenCombine and error handling via
+ * exceptionally / handle.
+ *
+ * Interview talking points:
+ *   - thenApply     : synchronous map (Function)
+ *   - thenCompose   : flatMap (Function returning CompletableFuture)
+ *   - thenCombine   : zip two independent CFs
+ *   - exceptionally : recover from failure
+ *   - Always supply an explicit Executor for blocking work - the default
+ *     ForkJoinPool.commonPool is shared with the JVM.
+ */
+public class CompletableFutureDemo {
+
+    public static void main(String[] args) throws ExecutionException, InterruptedException {
+        var exec = Executors.newFixedThreadPool(4);
+        try {
+            CompletableFuture<String> hello = CompletableFuture.supplyAsync(() -> "Hello", exec);
+            CompletableFuture<String> world = CompletableFuture.supplyAsync(() -> "World", exec);
+
+            String combined = hello.thenCombine(world, (h, w) -> h + " " + w).get();
+            System.out.println("combined = " + combined);
+
+            String pipeline = CompletableFuture.supplyAsync(() -> "42", exec)
+                    .thenApply(Integer::parseInt)
+                    .thenCompose(n -> CompletableFuture.supplyAsync(() -> "value=" + (n * 2), exec))
+                    .exceptionally(ex -> "fallback: " + ex.getMessage())
+                    .get();
+            System.out.println("pipeline = " + pipeline);
+
+            List<CompletableFuture<Integer>> tasks = List.of(
+                    CompletableFuture.supplyAsync(() -> compute(1), exec),
+                    CompletableFuture.supplyAsync(() -> compute(2), exec),
+                    CompletableFuture.supplyAsync(() -> compute(3), exec));
+
+            CompletableFuture<Void> all = CompletableFuture.allOf(tasks.toArray(CompletableFuture[]::new));
+            all.get();
+            int sum = tasks.stream().mapToInt(cf -> cf.join()).sum();
+            System.out.println("sum = " + sum);
+        } finally {
+            exec.shutdown();
+        }
+    }
+
+    private static int compute(int i) {
+        try { Thread.sleep(100); } catch (InterruptedException e) { Thread.currentThread().interrupt(); }
+        return i * i;
+    }
+}

--- a/java-features-reference/src/main/java/com/careerit/java/java08/DateTimeApi.java
+++ b/java-features-reference/src/main/java/com/careerit/java/java08/DateTimeApi.java
@@ -1,0 +1,61 @@
+package com.careerit.java.java08;
+
+import java.time.DayOfWeek;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.Month;
+import java.time.Period;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
+
+/**
+ * Java 8 - java.time (JSR-310).
+ *
+ * All core types are immutable and thread-safe.
+ *
+ *   LocalDate       - date only (no time, no zone)
+ *   LocalTime       - time only
+ *   LocalDateTime   - date + time, no zone
+ *   ZonedDateTime   - date + time + zone (use for user-facing timestamps)
+ *   Instant         - machine timestamp (UTC, epoch-based) - use for logging/storage
+ *   Period          - years/months/days (date-based)
+ *   Duration        - seconds/nanos (time-based)
+ */
+public class DateTimeApi {
+
+    public static void main(String[] args) {
+        LocalDate today = LocalDate.now();
+        LocalDate dob = LocalDate.of(1990, Month.JUNE, 15);
+        Period age = Period.between(dob, today);
+        System.out.println("age = " + age.getYears() + "y " + age.getMonths() + "m");
+
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime plus90Days = now.plusDays(90);
+        System.out.println("now + 90d = " + plus90Days);
+
+        ZonedDateTime nyc = ZonedDateTime.now(ZoneId.of("America/New_York"));
+        ZonedDateTime ist = nyc.withZoneSameInstant(ZoneId.of("Asia/Kolkata"));
+        System.out.println("NYC = " + nyc + " | IST = " + ist);
+
+        Instant start = Instant.now();
+        Instant end   = start.plus(Duration.ofMinutes(5));
+        System.out.println("millis between = " + Duration.between(start, end).toMillis());
+
+        DateTimeFormatter fmt = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+        System.out.println("formatted = " + now.format(fmt));
+
+        LocalDate nextFriday = today.with(java.time.temporal.TemporalAdjusters.next(DayOfWeek.FRIDAY));
+        System.out.println("next Friday = " + nextFriday);
+
+        long daysUntilNewYear = ChronoUnit.DAYS.between(today, LocalDate.of(today.getYear() + 1, 1, 1));
+        System.out.println("days until new year = " + daysUntilNewYear);
+
+        LocalTime noon = LocalTime.NOON;
+        System.out.println("noon + 90 min = " + noon.plusMinutes(90));
+    }
+}

--- a/java-features-reference/src/main/java/com/careerit/java/java08/DefaultStaticMethods.java
+++ b/java-features-reference/src/main/java/com/careerit/java/java08/DefaultStaticMethods.java
@@ -1,0 +1,51 @@
+package com.careerit.java.java08;
+
+/**
+ * Java 8 - default and static methods on interfaces.
+ *
+ * Before Java 8, adding a method to a published interface broke every implementation.
+ * `default` methods supply a body, so interfaces can evolve without breaking clients.
+ * `static` methods give interfaces a natural home for helper/factory methods.
+ *
+ * Diamond rule: when two interfaces provide the same default method, the implementing
+ * class MUST override it (use Interface.super.method() to pick one).
+ */
+public class DefaultStaticMethods {
+
+    interface Greeter {
+        String name();
+
+        default String greet() {
+            return "Hello, " + name();
+        }
+
+        static Greeter of(String n) {
+            return () -> n;
+        }
+    }
+
+    interface Logger {
+        default String greet() {
+            return "[log] greet called";
+        }
+    }
+
+    static class Friendly implements Greeter, Logger {
+        private final String n;
+        Friendly(String n) { this.n = n; }
+        @Override public String name() { return n; }
+
+        @Override
+        public String greet() {
+            return Greeter.super.greet() + " | " + Logger.super.greet();
+        }
+    }
+
+    public static void main(String[] args) {
+        Greeter g = Greeter.of("Ravi");
+        System.out.println(g.greet());
+
+        Friendly f = new Friendly("Asha");
+        System.out.println(f.greet());
+    }
+}

--- a/java-features-reference/src/main/java/com/careerit/java/java08/FunctionalInterfaces.java
+++ b/java-features-reference/src/main/java/com/careerit/java/java08/FunctionalInterfaces.java
@@ -1,0 +1,54 @@
+package com.careerit.java.java08;
+
+import java.util.function.BiFunction;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+import java.util.function.UnaryOperator;
+
+/**
+ * Java 8 - Built-in Functional Interfaces (java.util.function).
+ *
+ * Cheat sheet:
+ *   Function<T,R>       R apply(T t)            - transform one value
+ *   BiFunction<T,U,R>   R apply(T t, U u)       - two-arg transform
+ *   Predicate<T>        boolean test(T t)       - filter / condition
+ *   Consumer<T>         void accept(T t)        - side-effect / sink
+ *   Supplier<T>         T get()                 - factory / lazy value
+ *   UnaryOperator<T>    T apply(T t)            - Function<T,T>
+ *   BinaryOperator<T>   T apply(T a, T b)       - reducers
+ *
+ * Use @FunctionalInterface to mark your own SAM interfaces - compiler then
+ * enforces exactly one abstract method (default/static methods are allowed).
+ */
+public class FunctionalInterfaces {
+
+    @FunctionalInterface
+    interface TriFunction<A, B, C, R> {
+        R apply(A a, B b, C c);
+    }
+
+    public static void main(String[] args) {
+        Function<String, Integer> length = String::length;
+        Predicate<String> nonEmpty = s -> !s.isEmpty();
+        Consumer<String> printer = System.out::println;
+        Supplier<Long> now = System::currentTimeMillis;
+        UnaryOperator<Integer> square = x -> x * x;
+        BiFunction<Integer, Integer, Integer> add = Integer::sum;
+
+        printer.accept("len=" + length.apply("java"));
+        printer.accept("nonEmpty? " + nonEmpty.test("hi"));
+        printer.accept("now=" + now.get());
+        printer.accept("square(5)=" + square.apply(5));
+        printer.accept("add(2,3)=" + add.apply(2, 3));
+
+        Function<Integer, Integer> plus1 = x -> x + 1;
+        Function<Integer, Integer> times2 = x -> x * 2;
+        printer.accept("andThen: " + plus1.andThen(times2).apply(3)); // (3+1)*2 = 8
+        printer.accept("compose: " + plus1.compose(times2).apply(3)); // (3*2)+1 = 7
+
+        TriFunction<Integer, Integer, Integer, Integer> addThree = (a, b, c) -> a + b + c;
+        printer.accept("addThree=" + addThree.apply(1, 2, 3));
+    }
+}

--- a/java-features-reference/src/main/java/com/careerit/java/java08/LambdaExceptionHandling.java
+++ b/java-features-reference/src/main/java/com/careerit/java/java08/LambdaExceptionHandling.java
@@ -1,0 +1,97 @@
+package com.careerit.java.java08;
+
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * ============================================================================
+ *  Java 8 : CHECKED EXCEPTIONS IN LAMBDAS / STREAMS
+ * ============================================================================
+ *
+ *  THE PROBLEM
+ *  -----------
+ *  Built-in functional interfaces (Function, Predicate, ...) do NOT declare
+ *  checked exceptions. So this will NOT compile:
+ *
+ *      files.stream()
+ *           .map(path -> Files.readString(path))   // IOException is checked!
+ *           .collect(...);
+ *
+ *  THREE COMMON SOLUTIONS
+ *  ----------------------
+ *   A. try/catch INSIDE the lambda, convert to RuntimeException.
+ *   B. Write a small "throwing" functional interface + wrapper helper.
+ *   C. Use a library (vavr, Failsafe, Apache Commons) - but interviews care
+ *      more about seeing that you can do A + B from scratch.
+ *
+ *  This file demonstrates A and B.
+ * ============================================================================
+ */
+public class LambdaExceptionHandling {
+
+    // -------- Option B: custom throwing functional interface ---------
+    @FunctionalInterface
+    interface ThrowingFunction<T, R, E extends Exception> {
+        R apply(T t) throws E;
+    }
+
+    /**
+     * Wrap a throwing function so it can be used as a normal Function.
+     * Checked exceptions become RuntimeException (unchecked), which is
+     * propagated by the stream machinery.
+     */
+    static <T, R> Function<T, R> unchecked(ThrowingFunction<T, R, Exception> f) {
+        return t -> {
+            try {
+                return f.apply(t);
+            } catch (Exception e) {
+                if (e instanceof RuntimeException re) throw re;
+                throw new RuntimeException(e);
+            }
+        };
+    }
+
+    // A demo method that throws a checked exception
+    static int parseStrict(String s) throws Exception {
+        if (s == null || s.isBlank()) throw new Exception("empty input");
+        return Integer.parseInt(s.trim());
+    }
+
+    public static void main(String[] args) {
+        List<String> raw = List.of(" 10", "20 ", "30");
+
+        // ---------------------------------------------------------------
+        // A. try/catch inside the lambda
+        // ---------------------------------------------------------------
+        List<Integer> viaTryCatch = raw.stream()
+                .map(s -> {
+                    try {
+                        return parseStrict(s);
+                    } catch (Exception e) {
+                        throw new RuntimeException("bad input: " + s, e);
+                    }
+                })
+                .collect(Collectors.toList());
+        System.out.println("[A] " + viaTryCatch);
+
+        // ---------------------------------------------------------------
+        // B. Wrap once, reuse everywhere
+        // ---------------------------------------------------------------
+        List<Integer> viaWrapper = raw.stream()
+                .map(unchecked(LambdaExceptionHandling::parseStrict))
+                .collect(Collectors.toList());
+        System.out.println("[B] " + viaWrapper);
+
+        // ---------------------------------------------------------------
+        // Demonstrate propagation
+        // ---------------------------------------------------------------
+        try {
+            List.of("x").stream()
+                    .map(unchecked(LambdaExceptionHandling::parseStrict))
+                    .collect(Collectors.toList());
+        } catch (RuntimeException re) {
+            System.out.println("[propagate] caught: " + re.getCause().getMessage());
+        }
+    }
+}

--- a/java-features-reference/src/main/java/com/careerit/java/java08/LambdaExpressions.java
+++ b/java-features-reference/src/main/java/com/careerit/java/java08/LambdaExpressions.java
@@ -1,0 +1,35 @@
+package com.careerit.java.java08;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.BiFunction;
+
+/**
+ * Java 8 - Lambda Expressions.
+ *
+ * Syntax: (params) -> expression | { statements; }
+ *
+ * A lambda is an anonymous implementation of a functional interface (one abstract method).
+ * Common interview points:
+ *   - Captured local variables must be effectively final
+ *   - `this` inside a lambda refers to the enclosing class (unlike anonymous classes)
+ *   - Lambdas do not introduce a new scope for local variables
+ */
+public class LambdaExpressions {
+
+    public static void main(String[] args) {
+        Runnable r = () -> System.out.println("Running in a thread via lambda");
+        new Thread(r).start();
+
+        List<String> names = Arrays.asList("Ravi", "Kiran", "Asha");
+        names.forEach(n -> System.out.println("Hello, " + n));
+
+        BiFunction<Integer, Integer, Integer> add = (a, b) -> a + b;
+        System.out.println("2 + 3 = " + add.apply(2, 3));
+
+        int base = 10;
+        names.stream()
+             .map(n -> n + " [base=" + base + "]")
+             .forEach(System.out::println);
+    }
+}

--- a/java-features-reference/src/main/java/com/careerit/java/java08/LambdaExpressions.java
+++ b/java-features-reference/src/main/java/com/careerit/java/java08/LambdaExpressions.java
@@ -1,35 +1,156 @@
 package com.careerit.java.java08;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.List;
 import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.function.Predicate;
 
 /**
- * Java 8 - Lambda Expressions.
+ * ============================================================================
+ *  Java 8 : LAMBDA EXPRESSIONS
+ * ============================================================================
  *
- * Syntax: (params) -> expression | { statements; }
+ *  WHAT IS A LAMBDA?
+ *  -----------------
+ *  A lambda is just a shorter way to write an implementation of an interface
+ *  that has exactly ONE abstract method (a "functional interface").
  *
- * A lambda is an anonymous implementation of a functional interface (one abstract method).
- * Common interview points:
- *   - Captured local variables must be effectively final
- *   - `this` inside a lambda refers to the enclosing class (unlike anonymous classes)
- *   - Lambdas do not introduce a new scope for local variables
+ *  Anonymous class style (pre-Java 8):
+ *      Runnable r = new Runnable() {
+ *          public void run() { System.out.println("hi"); }
+ *      };
+ *
+ *  Lambda style (Java 8+):
+ *      Runnable r = () -> System.out.println("hi");
+ *
+ *  SYNTAX OPTIONS
+ *  --------------
+ *   ()             -> expr                         // no args
+ *   x              -> expr                         // one arg, no parentheses needed
+ *   (x, y)         -> expr                         // multiple args
+ *   (int x, int y) -> expr                         // explicit types
+ *   (x, y)         -> { stmt1; stmt2; return v; }  // block body
+ *
+ *  RULES YOU MUST KNOW FOR INTERVIEWS
+ *  ----------------------------------
+ *   1. Lambdas target "functional interfaces" (one abstract method).
+ *   2. Captured local variables must be EFFECTIVELY FINAL
+ *        - you can read them, but you can't reassign them after capture.
+ *   3. `this` inside a lambda refers to the enclosing CLASS instance,
+ *      NOT the lambda itself (different from anonymous classes).
+ *   4. A lambda does NOT introduce a new scope for local variables.
+ *      This means you cannot re-declare a variable from the enclosing method.
+ * ============================================================================
  */
 public class LambdaExpressions {
 
     public static void main(String[] args) {
-        Runnable r = () -> System.out.println("Running in a thread via lambda");
+
+        // ---------------------------------------------------------------
+        // 1. The simplest lambda: replace a Runnable
+        // ---------------------------------------------------------------
+        Runnable r = () -> System.out.println("[1] Hello from a lambda");
         new Thread(r).start();
 
+        // ---------------------------------------------------------------
+        // 2. Lambda with one parameter - parentheses optional
+        // ---------------------------------------------------------------
         List<String> names = Arrays.asList("Ravi", "Kiran", "Asha");
-        names.forEach(n -> System.out.println("Hello, " + n));
+        names.forEach(n -> System.out.println("[2] Hello, " + n));
 
+        // ---------------------------------------------------------------
+        // 3. Lambda with multiple parameters (BiFunction)
+        //    Takes two inputs, returns one output.
+        // ---------------------------------------------------------------
         BiFunction<Integer, Integer, Integer> add = (a, b) -> a + b;
-        System.out.println("2 + 3 = " + add.apply(2, 3));
+        System.out.println("[3] 2 + 3 = " + add.apply(2, 3));
 
-        int base = 10;
+        // ---------------------------------------------------------------
+        // 4. Block body with multiple statements and an explicit return
+        // ---------------------------------------------------------------
+        Function<String, String> banner = text -> {
+            String line = "=".repeat(text.length() + 4);
+            return line + "\n| " + text + " |\n" + line;
+        };
+        System.out.println("[4]\n" + banner.apply("Java 8"));
+
+        // ---------------------------------------------------------------
+        // 5. Sorting with Comparator - compact forms
+        // ---------------------------------------------------------------
+        List<String> people = new ArrayList<>(List.of("Ravi", "Asha", "Kiran", "Bob"));
+
+        // 5a. Sort alphabetically
+        people.sort((a, b) -> a.compareTo(b));
+
+        // 5b. Sort by length, then alphabetically (comparator chaining)
+        people.sort(Comparator
+                .comparingInt(String::length)
+                .thenComparing(Comparator.naturalOrder()));
+        System.out.println("[5] sorted by length then name = " + people);
+
+        // 5c. Reverse order
+        people.sort(Comparator.reverseOrder());
+        System.out.println("[5] reversed = " + people);
+
+        // ---------------------------------------------------------------
+        // 6. Predicate composition (and / or / negate)
+        // ---------------------------------------------------------------
+        Predicate<String> startsWithA = s -> s.startsWith("A");
+        Predicate<String> longerThan3 = s -> s.length() > 3;
+
         names.stream()
-             .map(n -> n + " [base=" + base + "]")
-             .forEach(System.out::println);
+                .filter(startsWithA.and(longerThan3))
+                .forEach(n -> System.out.println("[6a] A-name longer than 3: " + n));
+
+        names.stream()
+                .filter(startsWithA.negate())
+                .forEach(n -> System.out.println("[6b] NOT starting with A: " + n));
+
+        // ---------------------------------------------------------------
+        // 7. Function composition (andThen / compose)
+        //    andThen: run me, then the next
+        //    compose: run the OTHER first, then me
+        // ---------------------------------------------------------------
+        Function<Integer, Integer> times2 = x -> x * 2;
+        Function<Integer, Integer> plus3  = x -> x + 3;
+        System.out.println("[7a] (times2 andThen plus3)(5) = " + times2.andThen(plus3).apply(5)); // (5*2)+3 = 13
+        System.out.println("[7b] (times2 compose plus3)(5) = " + times2.compose(plus3).apply(5)); // (5+3)*2 = 16
+
+        // ---------------------------------------------------------------
+        // 8. Capturing local variables - must be effectively final
+        // ---------------------------------------------------------------
+        String greeting = "Hi";           // never reassigned => effectively final
+        Runnable greeter = () -> System.out.println("[8] " + greeting + "!");
+        greeter.run();
+
+        // The line below would FAIL to compile:
+        //   greeting = "Hello"; // Variable used in lambda should be final or effectively final
+        //   Runnable greeter2 = () -> System.out.println(greeting);
+
+        // ---------------------------------------------------------------
+        // 9. `this` inside a lambda = the enclosing class, not the lambda
+        // ---------------------------------------------------------------
+        new LambdaExpressions().demoThisReference();
+
+        // ---------------------------------------------------------------
+        // 10. Lambda vs anonymous class - a quick comparison
+        // ---------------------------------------------------------------
+        Runnable anon = new Runnable() {
+            @Override
+            public void run() { System.out.println("[10] anonymous class"); }
+        };
+        Runnable lamb = () -> System.out.println("[10] lambda");
+        anon.run();
+        lamb.run();
+    }
+
+    private final String name = "LambdaExpressions";
+
+    private void demoThisReference() {
+        Runnable r = () -> System.out.println("[9] this.name from lambda = " + this.name);
+        r.run();
     }
 }

--- a/java-features-reference/src/main/java/com/careerit/java/java08/MethodReferences.java
+++ b/java-features-reference/src/main/java/com/careerit/java/java08/MethodReferences.java
@@ -1,0 +1,48 @@
+package com.careerit.java.java08;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+/**
+ * Java 8 - Method References (shorthand for lambdas).
+ *
+ * Four kinds:
+ *   1. Static:            ClassName::staticMethod     (Integer::parseInt)
+ *   2. Bound instance:    instance::method            (System.out::println)
+ *   3. Unbound instance:  ClassName::method           (String::toUpperCase)
+ *   4. Constructor:       ClassName::new              (ArrayList::new)
+ */
+public class MethodReferences {
+
+    record Book(String title) {
+        static Book of(String t) { return new Book(t); }
+    }
+
+    public static void main(String[] args) {
+        Function<String, Integer> parseStatic = Integer::parseInt;
+        System.out.println(parseStatic.apply("42"));
+
+        StringBuilder sb = new StringBuilder("hi");
+        Supplier<String> boundToSb = sb::toString;
+        System.out.println(boundToSb.get());
+
+        Function<String, String> unboundUpper = String::toUpperCase;
+        System.out.println(unboundUpper.apply("java"));
+
+        Function<String, Book> ctorRef = Book::new;
+        System.out.println(ctorRef.apply("Effective Java"));
+
+        Function<String, Book> factory = Book::of;
+        System.out.println(factory.apply("Clean Code"));
+
+        List<String> names = Arrays.asList("Ravi", "Asha", "Kiran");
+        names.sort(String::compareToIgnoreCase);
+        names.forEach(System.out::println);
+
+        BiFunction<String, String, Boolean> startsWith = String::startsWith;
+        System.out.println(startsWith.apply("interview", "inter"));
+    }
+}

--- a/java-features-reference/src/main/java/com/careerit/java/java08/OptionalDemo.java
+++ b/java-features-reference/src/main/java/com/careerit/java/java08/OptionalDemo.java
@@ -1,0 +1,51 @@
+package com.careerit.java.java08;
+
+import java.util.Optional;
+
+/**
+ * Java 8 - Optional<T>.
+ *
+ * Optional is a container that either holds a value or is empty. It was designed
+ * as a method return type to make "absence" explicit, so callers don't forget to
+ * handle null.
+ *
+ * Do NOT use Optional for fields, method parameters, or collection elements.
+ * Do NOT call .get() without checking isPresent() - prefer orElse/orElseGet/orElseThrow.
+ *
+ * See also Java 9 additions: ifPresentOrElse, or, stream.
+ */
+public class OptionalDemo {
+
+    record User(String name, String email) {}
+
+    static Optional<User> findUser(String id) {
+        return "u1".equals(id) ? Optional.of(new User("Ravi", "ravi@example.com"))
+                               : Optional.empty();
+    }
+
+    public static void main(String[] args) {
+        Optional<User> u = findUser("u1");
+
+        u.ifPresent(user -> System.out.println("found: " + user));
+
+        String email = findUser("u-missing")
+                .map(User::email)
+                .orElse("no-email@example.com");
+        System.out.println("email = " + email);
+
+        String nameOrThrow = findUser("u1")
+                .map(User::name)
+                .orElseThrow(() -> new IllegalStateException("user not found"));
+        System.out.println("name = " + nameOrThrow);
+
+        Optional<String> value = Optional.ofNullable(System.getenv("NON_EXISTENT_VAR"));
+        System.out.println("value present? " + value.isPresent());
+
+        String computed = value.orElseGet(() -> expensiveDefault());
+        System.out.println("computed = " + computed);
+    }
+
+    private static String expensiveDefault() {
+        return "lazily-computed-default";
+    }
+}

--- a/java-features-reference/src/main/java/com/careerit/java/java08/OptionalDemo.java
+++ b/java-features-reference/src/main/java/com/careerit/java/java08/OptionalDemo.java
@@ -1,18 +1,47 @@
 package com.careerit.java.java08;
 
+import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 /**
- * Java 8 - Optional<T>.
+ * ============================================================================
+ *  Java 8 : Optional<T>
+ * ============================================================================
  *
- * Optional is a container that either holds a value or is empty. It was designed
- * as a method return type to make "absence" explicit, so callers don't forget to
- * handle null.
+ *  WHY DOES IT EXIST?
+ *  ------------------
+ *  To make "maybe null" EXPLICIT in method return types, so callers are forced
+ *  to decide what to do when a value is absent (instead of silently NPE'ing).
  *
- * Do NOT use Optional for fields, method parameters, or collection elements.
- * Do NOT call .get() without checking isPresent() - prefer orElse/orElseGet/orElseThrow.
+ *  HOW TO CREATE
+ *  -------------
+ *   Optional.of(x)           - x must not be null
+ *   Optional.ofNullable(x)   - wraps null as empty
+ *   Optional.empty()
  *
- * See also Java 9 additions: ifPresentOrElse, or, stream.
+ *  HOW TO CONSUME - SAFE WAYS
+ *  --------------------------
+ *   ifPresent(consumer)                - do something if present
+ *   orElse(default)                    - always evaluates default
+ *   orElseGet(supplier)                - lazy default
+ *   orElseThrow() / orElseThrow(sup)   - assert present
+ *   map / filter / flatMap             - transform while safe
+ *   isPresent / isEmpty (Java 11)      - check flag (avoid in favor of the above)
+ *
+ *  INTERVIEW TRAP: .get()
+ *  ----------------------
+ *  .get() throws NoSuchElementException if empty. Almost never use it directly -
+ *  prefer orElseXxx or map/ifPresent. Linters flag .get() without isPresent().
+ *
+ *  WHEN NOT TO USE Optional
+ *  ------------------------
+ *   - fields / entity attributes
+ *   - method parameters
+ *   - as elements of collections
+ *   - for primitives (use OptionalInt/OptionalLong/OptionalDouble)
+ *   Designed for RETURN TYPES of library methods.
+ * ============================================================================
  */
 public class OptionalDemo {
 
@@ -24,28 +53,111 @@ public class OptionalDemo {
     }
 
     public static void main(String[] args) {
-        Optional<User> u = findUser("u1");
 
-        u.ifPresent(user -> System.out.println("found: " + user));
+        // ---------------------------------------------------------------
+        // 1. Creation patterns
+        // ---------------------------------------------------------------
+        Optional<String> a = Optional.of("hi");
+        Optional<String> b = Optional.ofNullable(null);      // empty
+        Optional<String> c = Optional.empty();
+        System.out.println("[1] " + a + " / " + b + " / " + c);
 
-        String email = findUser("u-missing")
+        // ---------------------------------------------------------------
+        // 2. Safely react to presence
+        // ---------------------------------------------------------------
+        findUser("u1").ifPresent(u -> System.out.println("[2] found: " + u));
+        findUser("u-missing").ifPresent(u -> System.out.println("should NOT print"));
+
+        // ---------------------------------------------------------------
+        // 3. Provide a default: orElse vs orElseGet
+        //    orElse evaluates the default ALWAYS (even when present).
+        //    orElseGet only evaluates the supplier when EMPTY.
+        //    -> use orElseGet when computing the default is expensive.
+        // ---------------------------------------------------------------
+        String eagerDefault = findUser("u1")
                 .map(User::email)
-                .orElse("no-email@example.com");
-        System.out.println("email = " + email);
+                .orElse(expensive("orElse-eager"));
 
+        String lazyDefault = findUser("u1")
+                .map(User::email)
+                .orElseGet(() -> expensive("orElseGet-lazy"));
+
+        System.out.println("[3a] eager=" + eagerDefault);
+        System.out.println("[3b] lazy =" + lazyDefault);
+
+        // ---------------------------------------------------------------
+        // 4. Assert present - orElseThrow
+        // ---------------------------------------------------------------
         String nameOrThrow = findUser("u1")
                 .map(User::name)
                 .orElseThrow(() -> new IllegalStateException("user not found"));
-        System.out.println("name = " + nameOrThrow);
+        System.out.println("[4] name = " + nameOrThrow);
 
-        Optional<String> value = Optional.ofNullable(System.getenv("NON_EXISTENT_VAR"));
-        System.out.println("value present? " + value.isPresent());
+        // ---------------------------------------------------------------
+        // 5. map vs flatMap
+        //    map      : function returns a plain value   -> Optional<R>
+        //    flatMap  : function returns an Optional     -> Optional<R> (no nesting)
+        // ---------------------------------------------------------------
+        Optional<Integer> emailLen = findUser("u1")
+                .map(User::email)            // Optional<String>
+                .map(String::length);        // Optional<Integer>
+        System.out.println("[5] email length = " + emailLen.orElse(0));
 
-        String computed = value.orElseGet(() -> expensiveDefault());
-        System.out.println("computed = " + computed);
+        Optional<String> upperEmail = findUser("u1")
+                .flatMap(u -> Optional.ofNullable(u.email())) // already Optional, no nesting
+                .map(String::toUpperCase);
+        System.out.println("[5] upperEmail = " + upperEmail);
+
+        // ---------------------------------------------------------------
+        // 6. filter - keep only if predicate holds
+        // ---------------------------------------------------------------
+        findUser("u1")
+                .filter(u -> u.email().endsWith(".com"))
+                .ifPresent(u -> System.out.println("[6] .com user = " + u.name()));
+
+        // ---------------------------------------------------------------
+        // 7. Chain multiple optional lookups (the "Service style")
+        // ---------------------------------------------------------------
+        String masked = findUser("u1")
+                .map(User::email)
+                .filter(e -> e.contains("@"))
+                .map(e -> e.substring(0, 2) + "***" + e.substring(e.indexOf("@")))
+                .orElse("n/a");
+        System.out.println("[7] masked email = " + masked);
+
+        // ---------------------------------------------------------------
+        // 8. Common ANTI-PATTERNS (don't do these in interviews)
+        // ---------------------------------------------------------------
+        Optional<User> u = findUser("u1");
+
+        //  BAD: if (u.isPresent()) { ... u.get() ... } else { ... }
+        //  GOOD: ifPresentOrElse (Java 9) or u.map(...).orElse(...)
+
+        //  BAD: return Optional.ofNullable(nullable) as a FIELD type.
+        //  BAD: passing Optional as a method parameter. Just overload / allow null.
+
+        // ---------------------------------------------------------------
+        // 9. Working with a List of Optionals (collect the present values)
+        // ---------------------------------------------------------------
+        List<Optional<String>> lookups = List.of(
+                Optional.of("alpha"),
+                Optional.empty(),
+                Optional.of("beta"),
+                Optional.empty(),
+                Optional.of("gamma"));
+
+        // Java 8 style:
+        List<String> presentValuesJ8 = lookups.stream()
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .collect(Collectors.toList());
+
+        // Java 9+ nicer style (flatMap + Optional.stream) - shown in java09/
+        System.out.println("[9] present = " + presentValuesJ8);
     }
 
-    private static String expensiveDefault() {
-        return "lazily-computed-default";
+    private static String expensive(String tag) {
+        System.out.println("    (computing " + tag + " ...)");
+        return "expensive-" + tag;
     }
 }

--- a/java-features-reference/src/main/java/com/careerit/java/java08/ParallelStreams.java
+++ b/java-features-reference/src/main/java/com/careerit/java/java08/ParallelStreams.java
@@ -1,0 +1,103 @@
+package com.careerit.java.java08;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+/**
+ * ============================================================================
+ *  Java 8 : PARALLEL STREAMS
+ * ============================================================================
+ *
+ *  .parallelStream()  or  .stream().parallel()
+ *
+ *  Runs the pipeline on the common ForkJoinPool. Can speed up CPU-heavy work,
+ *  but is a performance FOOTGUN in many interview-relevant ways.
+ *
+ *  USE WHEN...
+ *  -----------
+ *   * The operation per element is expensive (math, hashing, parsing).
+ *   * The source is cheap to split (ArrayList, int[], IntStream.range).
+ *   * The pipeline is stateless and has no shared mutable state.
+ *   * Order doesn't matter (or you accept the cost of forcing it).
+ *
+ *  AVOID WHEN...
+ *  -------------
+ *   * Element work is cheap (overhead > speedup).
+ *   * Source is LinkedList / Stream.iterate (hard to split evenly).
+ *   * You share a non-thread-safe collector (HashMap, ArrayList).
+ *   * You're already inside a request thread / ForkJoinPool - you may starve it.
+ *
+ *  ORDER
+ *  -----
+ *  Parallel streams may PROCESS out of order, but ordered sources + ordered
+ *  collectors preserve encounter order in the RESULT (at some cost). Use
+ *  .unordered() to allow more parallelism when you don't need order.
+ * ============================================================================
+ */
+public class ParallelStreams {
+
+    public static void main(String[] args) {
+
+        // ---------------------------------------------------------------
+        // 1. Sequential vs parallel - same answer, different speed profile
+        // ---------------------------------------------------------------
+        long seq = time(() -> IntStream.rangeClosed(1, 1_000_000)
+                .filter(ParallelStreams::isPrime)
+                .count());
+        long par = time(() -> IntStream.rangeClosed(1, 1_000_000)
+                .parallel()
+                .filter(ParallelStreams::isPrime)
+                .count());
+        System.out.println("[1] sequential ms = " + seq);
+        System.out.println("[1] parallel   ms = " + par);
+
+        // ---------------------------------------------------------------
+        // 2. Order preservation
+        //    forEach         - parallel may print out of order
+        //    forEachOrdered  - parallel preserves encounter order (slower)
+        // ---------------------------------------------------------------
+        System.out.print("[2] forEach        : ");
+        List.of(1, 2, 3, 4, 5, 6, 7, 8).parallelStream().forEach(i -> System.out.print(i + " "));
+        System.out.println();
+        System.out.print("[2] forEachOrdered : ");
+        List.of(1, 2, 3, 4, 5, 6, 7, 8).parallelStream().forEachOrdered(i -> System.out.print(i + " "));
+        System.out.println();
+
+        // ---------------------------------------------------------------
+        // 3. SHARED MUTABLE STATE = bug
+        // ---------------------------------------------------------------
+        AtomicInteger safeCounter = new AtomicInteger();
+        int plainCounter[] = {0};  // unsafe, demonstrates the bug
+        IntStream.rangeClosed(1, 100_000).parallel().forEach(i -> {
+            safeCounter.incrementAndGet();
+            plainCounter[0]++;            // race condition - not guaranteed 100000
+        });
+        System.out.println("[3] atomic  = " + safeCounter.get());
+        System.out.println("[3] unsafe  = " + plainCounter[0] + " (often < 100000)");
+
+        // ---------------------------------------------------------------
+        // 4. Correct way to aggregate in parallel: reduce or a concurrent collector
+        // ---------------------------------------------------------------
+        int sum = IntStream.rangeClosed(1, 100).parallel().reduce(0, Integer::sum);
+        System.out.println("[4] sum 1..100 = " + sum);
+
+        // groupingByConcurrent returns a ConcurrentMap and can merge in parallel
+        var lengths = List.of("a", "bb", "ccc", "dd", "eeee").parallelStream()
+                .collect(Collectors.groupingByConcurrent(String::length));
+        System.out.println("[4] concurrent group = " + lengths);
+    }
+
+    private static boolean isPrime(int n) {
+        if (n < 2) return false;
+        for (int i = 2; (long) i * i <= n; i++) if (n % i == 0) return false;
+        return true;
+    }
+
+    private static long time(Runnable r) {
+        long t0 = System.currentTimeMillis();
+        r.run();
+        return System.currentTimeMillis() - t0;
+    }
+}

--- a/java-features-reference/src/main/java/com/careerit/java/java08/StreamAdvanced.java
+++ b/java-features-reference/src/main/java/com/careerit/java/java08/StreamAdvanced.java
@@ -1,0 +1,141 @@
+package com.careerit.java.java08;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.stream.Collectors;
+
+/**
+ * ============================================================================
+ *  Java 8 : STREAM API - PATTERNS FROM REAL INTERVIEWS
+ * ============================================================================
+ *
+ *  A collection of small, self-contained problems you're likely to be asked.
+ *  Each one is labelled with the pattern that solves it.
+ * ============================================================================
+ */
+public class StreamAdvanced {
+
+    record Order(String customer, String product, String category, double amount) {}
+
+    static final List<Order> ORDERS = List.of(
+            new Order("Ravi",  "Laptop",   "Electronics", 1200),
+            new Order("Ravi",  "Mouse",    "Electronics",   25),
+            new Order("Asha",  "Book",     "Books",         40),
+            new Order("Asha",  "Headset",  "Electronics",  150),
+            new Order("Kiran", "Book",     "Books",         30),
+            new Order("Kiran", "Book",     "Books",         30),
+            new Order("Mira",  "Notebook", "Stationery",    12));
+
+    public static void main(String[] args) {
+
+        // ---------------------------------------------------------------
+        // Problem 1: total spend per customer
+        // Pattern: groupingBy + summingDouble
+        // ---------------------------------------------------------------
+        Map<String, Double> totalPerCustomer = ORDERS.stream()
+                .collect(Collectors.groupingBy(
+                        Order::customer,
+                        Collectors.summingDouble(Order::amount)));
+        System.out.println("[1] totalPerCustomer = " + totalPerCustomer);
+
+        // ---------------------------------------------------------------
+        // Problem 2: top customer (highest total spend)
+        // Pattern: groupingBy + summingDouble + max by value
+        // ---------------------------------------------------------------
+        String topCustomer = totalPerCustomer.entrySet().stream()
+                .max(Map.Entry.comparingByValue())
+                .map(Map.Entry::getKey)
+                .orElse("n/a");
+        System.out.println("[2] topCustomer = " + topCustomer);
+
+        // ---------------------------------------------------------------
+        // Problem 3: count orders per category
+        // Pattern: groupingBy + counting
+        // ---------------------------------------------------------------
+        Map<String, Long> ordersPerCategory = ORDERS.stream()
+                .collect(Collectors.groupingBy(Order::category, Collectors.counting()));
+        System.out.println("[3] ordersPerCategory = " + ordersPerCategory);
+
+        // ---------------------------------------------------------------
+        // Problem 4: customers who bought from more than one category
+        // Pattern: groupingBy + mapping + toSet + filter
+        // ---------------------------------------------------------------
+        Map<String, Set<String>> catsPerCustomer = ORDERS.stream()
+                .collect(Collectors.groupingBy(
+                        Order::customer,
+                        Collectors.mapping(Order::category, Collectors.toSet())));
+
+        List<String> diverseShoppers = catsPerCustomer.entrySet().stream()
+                .filter(e -> e.getValue().size() > 1)
+                .map(Map.Entry::getKey)
+                .collect(Collectors.toList());
+        System.out.println("[4] diverseShoppers = " + diverseShoppers);
+
+        // ---------------------------------------------------------------
+        // Problem 5: frequency count of "product" words
+        // Pattern: groupingBy(identity) + counting
+        // ---------------------------------------------------------------
+        Map<String, Long> wordFreq = ORDERS.stream()
+                .map(Order::product)
+                .collect(Collectors.groupingBy(java.util.function.Function.identity(),
+                        Collectors.counting()));
+        System.out.println("[5] wordFreq = " + wordFreq);
+
+        // ---------------------------------------------------------------
+        // Problem 6: most expensive order per category
+        // Pattern: groupingBy + collectingAndThen + maxBy
+        // ---------------------------------------------------------------
+        Map<String, Order> maxPerCat = ORDERS.stream()
+                .collect(Collectors.groupingBy(
+                        Order::category,
+                        Collectors.collectingAndThen(
+                                Collectors.maxBy(Comparator.comparingDouble(Order::amount)),
+                                opt -> opt.orElseThrow())));
+        System.out.println("[6] maxPerCat = " + maxPerCat);
+
+        // ---------------------------------------------------------------
+        // Problem 7: sorted output - TreeMap grouping
+        // Pattern: groupingBy(classifier, TreeMap::new, downstream)
+        // ---------------------------------------------------------------
+        TreeMap<String, Double> totalPerCategorySorted = ORDERS.stream()
+                .collect(Collectors.groupingBy(
+                        Order::category,
+                        TreeMap::new,
+                        Collectors.summingDouble(Order::amount)));
+        System.out.println("[7] totalPerCategorySorted = " + totalPerCategorySorted);
+
+        // ---------------------------------------------------------------
+        // Problem 8: CSV-style output
+        // Pattern: joining(delimiter, prefix, suffix)
+        // ---------------------------------------------------------------
+        String csv = ORDERS.stream()
+                .map(Order::product)
+                .distinct()
+                .collect(Collectors.joining(", ", "[", "]"));
+        System.out.println("[8] csv = " + csv);
+
+        // ---------------------------------------------------------------
+        // Problem 9: partition into free-shipping-eligible (amount >= 50)
+        // Pattern: partitioningBy
+        // ---------------------------------------------------------------
+        Map<Boolean, List<Order>> eligible = ORDERS.stream()
+                .collect(Collectors.partitioningBy(o -> o.amount() >= 50));
+        System.out.println("[9] free-shipping = " + eligible.get(true));
+        System.out.println("[9] paid-shipping = " + eligible.get(false));
+
+        // ---------------------------------------------------------------
+        // Problem 10: dedupe by a field (keep first) - common trick
+        // Pattern: toMap with merge function
+        // ---------------------------------------------------------------
+        Map<String, Order> firstPerCustomer = ORDERS.stream()
+                .collect(Collectors.toMap(
+                        Order::customer,
+                        o -> o,
+                        (first, second) -> first,   // keep first
+                        java.util.LinkedHashMap::new));
+        System.out.println("[10] firstPerCustomer = " + firstPerCustomer);
+    }
+}

--- a/java-features-reference/src/main/java/com/careerit/java/java08/StreamApi.java
+++ b/java-features-reference/src/main/java/com/careerit/java/java08/StreamApi.java
@@ -1,67 +1,210 @@
 package com.careerit.java.java08;
 
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 /**
- * Java 8 - Stream API.
+ * ============================================================================
+ *  Java 8 : STREAM API - the BIG one for interviews
+ * ============================================================================
  *
- * A Stream is a pipeline: source -> 0..n intermediate ops -> terminal op.
- * Intermediate ops (filter/map/sorted/distinct/...) are lazy.
- * Terminal ops (collect/forEach/reduce/count/...) trigger execution.
+ *  MENTAL MODEL
+ *  ------------
+ *  A Stream is a PIPELINE, not a data structure:
  *
- * Streams do not store data, do not modify the source, and are consumed once.
- * Prefer sequential; go parallel only after measuring - parallelism has overhead
- * and ordering/thread-safety implications.
+ *     source  -->  0..n intermediate ops  -->  1 terminal op
+ *     (List,      (filter/map/sorted/...)     (collect/forEach/
+ *      array,                                   count/reduce/...)
+ *      Stream.of,
+ *      IntStream.range,
+ *      Files.lines,
+ *      ...)
+ *
+ *  FOUR FACTS YOU MUST KNOW
+ *  ------------------------
+ *   1. Intermediate ops are LAZY. Nothing runs until a terminal op is called.
+ *   2. Streams are consumed ONCE. After a terminal op, the stream is closed.
+ *   3. Streams do NOT modify the source collection.
+ *   4. Streams are NOT data structures. Don't "store" them.
+ *
+ *  INTERMEDIATE vs TERMINAL (most common ones)
+ *  -------------------------------------------
+ *   Intermediate: filter, map, flatMap, distinct, sorted, peek, limit, skip
+ *   Terminal    : collect, forEach, reduce, count, min/max, findFirst,
+ *                 findAny, anyMatch, allMatch, noneMatch, toArray, toList (Java 16)
+ *
+ *  SHORT-CIRCUITING TERMINAL OPS
+ *  -----------------------------
+ *   findFirst, findAny, anyMatch, allMatch, noneMatch, limit.
+ *   These stop as soon as the answer is known - great for infinite streams.
+ *
+ *  PRIMITIVE STREAMS
+ *  -----------------
+ *   IntStream, LongStream, DoubleStream - avoid boxing, add sum/avg/etc.
+ *   Convert with mapToInt / boxed().
+ * ============================================================================
  */
 public class StreamApi {
 
-    record Employee(String name, String dept, double salary) {}
+    record Employee(String name, String dept, double salary, int age) {}
 
     public static void main(String[] args) {
+
         List<Integer> nums = Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
 
+        List<Employee> employees = List.of(
+                new Employee("Ravi",  "ENG", 90_000,  28),
+                new Employee("Asha",  "ENG", 120_000, 35),
+                new Employee("Kiran", "HR",  60_000,  30),
+                new Employee("Mira",  "HR",  75_000,  40),
+                new Employee("Sam",   "SALES", 85_000, 25));
+
+        // ---------------------------------------------------------------
+        // 1. Classic filter + map + collect
+        // ---------------------------------------------------------------
+        List<String> engineerNames = employees.stream()
+                .filter(e -> e.dept().equals("ENG"))
+                .map(Employee::name)
+                .collect(Collectors.toList());
+        System.out.println("[1] engineers = " + engineerNames);
+
+        // ---------------------------------------------------------------
+        // 2. mapToInt -> sum/avg (primitive stream, no boxing)
+        // ---------------------------------------------------------------
         int sumOfSquaresOfEvens = nums.stream()
                 .filter(n -> n % 2 == 0)
                 .mapToInt(n -> n * n)
                 .sum();
-        System.out.println("sumOfSquaresOfEvens = " + sumOfSquaresOfEvens);
+        System.out.println("[2] sum of squares of evens = " + sumOfSquaresOfEvens);
 
-        List<String> upper = Stream.of("a", "b", "c")
-                .map(String::toUpperCase)
-                .collect(Collectors.toList());
-        System.out.println(upper);
+        double avgSalary = employees.stream()
+                .mapToDouble(Employee::salary)
+                .average()
+                .orElse(0);
+        System.out.println("[2] avg salary = " + avgSalary);
 
+        // ---------------------------------------------------------------
+        // 3. reduce - fold the stream down to a single value
+        //    3 flavours: identity+accumulator, accumulator only, combiner
+        // ---------------------------------------------------------------
         int factorial5 = IntStream.rangeClosed(1, 5).reduce(1, (a, b) -> a * b);
-        System.out.println("5! = " + factorial5);
+        System.out.println("[3] 5! = " + factorial5);
 
-        List<Employee> employees = List.of(
-                new Employee("Ravi",  "ENG", 90_000),
-                new Employee("Asha",  "ENG", 120_000),
-                new Employee("Kiran", "HR",   60_000),
-                new Employee("Mira",  "HR",   75_000));
+        Optional<String> longest = employees.stream()
+                .map(Employee::name)
+                .reduce((a, b) -> a.length() >= b.length() ? a : b);
+        longest.ifPresent(n -> System.out.println("[3] longest name = " + n));
 
-        Map<String, Double> avgByDept = employees.stream()
-                .collect(Collectors.groupingBy(Employee::dept,
-                        Collectors.averagingDouble(Employee::salary)));
-        System.out.println("avgByDept = " + avgByDept);
+        // ---------------------------------------------------------------
+        // 4. Sorting inside a stream
+        //    Natural, reverse, custom, multi-level
+        // ---------------------------------------------------------------
+        List<Employee> top3 = employees.stream()
+                .sorted(Comparator.comparingDouble(Employee::salary).reversed())
+                .limit(3)
+                .collect(Collectors.toList());
+        System.out.println("[4] top 3 paid = " + top3);
 
-        String topEarnerPerDept = employees.stream()
-                .collect(Collectors.groupingBy(Employee::dept,
-                        Collectors.collectingAndThen(
-                                Collectors.maxBy((a, b) -> Double.compare(a.salary(), b.salary())),
-                                e -> e.map(Employee::name).orElse("-"))))
-                .toString();
-        System.out.println("topEarnerPerDept = " + topEarnerPerDept);
+        // ---------------------------------------------------------------
+        // 5. distinct + count
+        // ---------------------------------------------------------------
+        long deptCount = employees.stream().map(Employee::dept).distinct().count();
+        System.out.println("[5] distinct departments = " + deptCount);
 
+        // ---------------------------------------------------------------
+        // 6. anyMatch / allMatch / noneMatch - short-circuit
+        // ---------------------------------------------------------------
+        boolean anyMinor   = employees.stream().anyMatch(e -> e.age() < 18);
+        boolean allAdults  = employees.stream().allMatch(e -> e.age() >= 18);
+        boolean noneOver99 = employees.stream().noneMatch(e -> e.age() > 99);
+        System.out.println("[6] anyMinor=" + anyMinor + ", allAdults=" + allAdults + ", noneOver99=" + noneOver99);
+
+        // ---------------------------------------------------------------
+        // 7. findFirst vs findAny
+        //    findFirst respects encounter order; findAny may be faster in parallel.
+        // ---------------------------------------------------------------
+        Optional<Employee> first = employees.stream()
+                .filter(e -> e.salary() > 80_000)
+                .findFirst();
+        first.ifPresent(e -> System.out.println("[7] first > 80k = " + e.name()));
+
+        // ---------------------------------------------------------------
+        // 8. flatMap - "flatten" a Stream of Streams into one Stream
+        //    Classic: words in a sentence, or values of nested lists.
+        // ---------------------------------------------------------------
         long uniqueWords = Stream.of("to be", "or not", "to be")
                 .flatMap(s -> Arrays.stream(s.split(" ")))
                 .distinct()
                 .count();
-        System.out.println("uniqueWords = " + uniqueWords);
+        System.out.println("[8] unique words = " + uniqueWords);
+
+        List<List<Integer>> nested = List.of(List.of(1, 2), List.of(3, 4), List.of(5));
+        List<Integer> flat = nested.stream()
+                .flatMap(List::stream)
+                .collect(Collectors.toList());
+        System.out.println("[8] flat = " + flat);
+
+        // ---------------------------------------------------------------
+        // 9. peek - debugging/logging WITHOUT changing the stream
+        //    Only runs if there's a terminal op that actually consumes items.
+        // ---------------------------------------------------------------
+        long seen = Stream.of("a", "b", "c")
+                .peek(v -> System.out.println("[9] peek: " + v))
+                .count();
+        System.out.println("[9] seen = " + seen);
+
+        // ---------------------------------------------------------------
+        // 10. groupingBy - a whole sub-API. Here: grouping + counting + averaging
+        // ---------------------------------------------------------------
+        Map<String, Double> avgByDept = employees.stream()
+                .collect(Collectors.groupingBy(Employee::dept,
+                        Collectors.averagingDouble(Employee::salary)));
+        System.out.println("[10] avgByDept = " + avgByDept);
+
+        // ---------------------------------------------------------------
+        // 11. partitioningBy - a true/false split in a single pass
+        // ---------------------------------------------------------------
+        Map<Boolean, List<Employee>> youngVsOld = employees.stream()
+                .collect(Collectors.partitioningBy(e -> e.age() < 30));
+        System.out.println("[11] young = " + youngVsOld.get(true));
+        System.out.println("[11] rest  = " + youngVsOld.get(false));
+
+        // ---------------------------------------------------------------
+        // 12. toMap - be careful about duplicate keys
+        // ---------------------------------------------------------------
+        Map<String, Double> salaryByName = employees.stream()
+                .collect(Collectors.toMap(Employee::name, Employee::salary));
+        System.out.println("[12] salaryByName = " + salaryByName);
+
+        // If keys can collide, supply a merge function:
+        Map<String, Double> totalByDept = employees.stream()
+                .collect(Collectors.toMap(Employee::dept, Employee::salary, Double::sum));
+        System.out.println("[12] totalByDept = " + totalByDept);
+
+        // ---------------------------------------------------------------
+        // 13. Stream generators - iterate / generate
+        //    Infinite streams! Remember to call limit() somewhere.
+        // ---------------------------------------------------------------
+        List<Integer> firstFivePowers = Stream.iterate(1, i -> i * 2)
+                .limit(5)
+                .collect(Collectors.toList());
+        System.out.println("[13] 1,2,4,8,16 = " + firstFivePowers);
+
+        // ---------------------------------------------------------------
+        // 14. Streams are consumed ONCE - demonstrate the common bug
+        // ---------------------------------------------------------------
+        Stream<Integer> once = Stream.of(1, 2, 3);
+        System.out.println("[14] count=" + once.count());
+        try {
+            once.forEach(System.out::println); // throws IllegalStateException
+        } catch (IllegalStateException ex) {
+            System.out.println("[14] cannot reuse stream: " + ex.getMessage());
+        }
     }
 }

--- a/java-features-reference/src/main/java/com/careerit/java/java08/StreamApi.java
+++ b/java-features-reference/src/main/java/com/careerit/java/java08/StreamApi.java
@@ -1,0 +1,67 @@
+package com.careerit.java.java08;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+/**
+ * Java 8 - Stream API.
+ *
+ * A Stream is a pipeline: source -> 0..n intermediate ops -> terminal op.
+ * Intermediate ops (filter/map/sorted/distinct/...) are lazy.
+ * Terminal ops (collect/forEach/reduce/count/...) trigger execution.
+ *
+ * Streams do not store data, do not modify the source, and are consumed once.
+ * Prefer sequential; go parallel only after measuring - parallelism has overhead
+ * and ordering/thread-safety implications.
+ */
+public class StreamApi {
+
+    record Employee(String name, String dept, double salary) {}
+
+    public static void main(String[] args) {
+        List<Integer> nums = Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+
+        int sumOfSquaresOfEvens = nums.stream()
+                .filter(n -> n % 2 == 0)
+                .mapToInt(n -> n * n)
+                .sum();
+        System.out.println("sumOfSquaresOfEvens = " + sumOfSquaresOfEvens);
+
+        List<String> upper = Stream.of("a", "b", "c")
+                .map(String::toUpperCase)
+                .collect(Collectors.toList());
+        System.out.println(upper);
+
+        int factorial5 = IntStream.rangeClosed(1, 5).reduce(1, (a, b) -> a * b);
+        System.out.println("5! = " + factorial5);
+
+        List<Employee> employees = List.of(
+                new Employee("Ravi",  "ENG", 90_000),
+                new Employee("Asha",  "ENG", 120_000),
+                new Employee("Kiran", "HR",   60_000),
+                new Employee("Mira",  "HR",   75_000));
+
+        Map<String, Double> avgByDept = employees.stream()
+                .collect(Collectors.groupingBy(Employee::dept,
+                        Collectors.averagingDouble(Employee::salary)));
+        System.out.println("avgByDept = " + avgByDept);
+
+        String topEarnerPerDept = employees.stream()
+                .collect(Collectors.groupingBy(Employee::dept,
+                        Collectors.collectingAndThen(
+                                Collectors.maxBy((a, b) -> Double.compare(a.salary(), b.salary())),
+                                e -> e.map(Employee::name).orElse("-"))))
+                .toString();
+        System.out.println("topEarnerPerDept = " + topEarnerPerDept);
+
+        long uniqueWords = Stream.of("to be", "or not", "to be")
+                .flatMap(s -> Arrays.stream(s.split(" ")))
+                .distinct()
+                .count();
+        System.out.println("uniqueWords = " + uniqueWords);
+    }
+}

--- a/java-features-reference/src/main/java/com/careerit/java/java09/CollectionFactories.java
+++ b/java-features-reference/src/main/java/com/careerit/java/java09/CollectionFactories.java
@@ -1,0 +1,38 @@
+package com.careerit.java.java09;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Java 9 - Immutable collection factory methods.
+ *
+ *   List.of(...), Set.of(...), Map.of(k,v,...), Map.ofEntries(entry, entry, ...)
+ *
+ * Differences from Collections.unmodifiableList(new ArrayList<>(...)):
+ *   - null elements/keys/values are rejected
+ *   - duplicate set elements / map keys throw IllegalArgumentException at creation
+ *   - structurally immutable (no set/add/remove)
+ *   - space-efficient (specialized classes for small sizes)
+ */
+public class CollectionFactories {
+
+    public static void main(String[] args) {
+        List<String> list = List.of("a", "b", "c");
+        Set<Integer> set   = Set.of(1, 2, 3);
+        Map<String, Integer> map = Map.of("one", 1, "two", 2);
+        Map<String, Integer> bigMap = Map.ofEntries(
+                Map.entry("jan", 1), Map.entry("feb", 2), Map.entry("mar", 3));
+
+        System.out.println(list);
+        System.out.println(set);
+        System.out.println(map);
+        System.out.println(bigMap);
+
+        try {
+            list.add("d");
+        } catch (UnsupportedOperationException e) {
+            System.out.println("immutable: cannot add");
+        }
+    }
+}

--- a/java-features-reference/src/main/java/com/careerit/java/java09/PrivateInterfaceMethods.java
+++ b/java-features-reference/src/main/java/com/careerit/java/java09/PrivateInterfaceMethods.java
@@ -1,0 +1,38 @@
+package com.careerit.java.java09;
+
+import java.util.List;
+
+/**
+ * Java 9 - private (and private static) methods on interfaces.
+ *
+ * Lets multiple default methods share helper code without exposing it as API.
+ */
+public class PrivateInterfaceMethods {
+
+    interface Reporter {
+        default String short_() { return header() + format("short"); }
+        default String long_()  { return header() + format("long"); }
+
+        private String header() { return "[report] "; }
+        private static String format(String kind) { return "kind=" + kind; }
+    }
+
+    interface ModuleNote {
+        /*
+         * Java 9 also introduced the module system (JPMS) via module-info.java:
+         *
+         *   module com.careerit.javaref {
+         *       requires java.net.http;
+         *       exports com.careerit.java.java09;
+         *   }
+         *
+         * This demo module intentionally stays on the unnamed module / classpath
+         * to avoid forcing every consumer to modularize. See Oracle JEP 261.
+         */
+    }
+
+    public static void main(String[] args) {
+        Reporter r = new Reporter() {};
+        System.out.println(List.of(r.short_(), r.long_()));
+    }
+}

--- a/java-features-reference/src/main/java/com/careerit/java/java09/StreamAndOptionalImprovements.java
+++ b/java-features-reference/src/main/java/com/careerit/java/java09/StreamAndOptionalImprovements.java
@@ -1,0 +1,49 @@
+package com.careerit.java.java09;
+
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Java 9 - small but high-value additions.
+ *
+ * Stream:
+ *   takeWhile(pred)   - prefix while predicate holds
+ *   dropWhile(pred)   - drop prefix while predicate holds, keep the rest
+ *   ofNullable(t)     - empty stream if null, else stream of one
+ *   iterate(seed, hasNext, next) - bounded iterate (3-arg)
+ *
+ * Optional:
+ *   ifPresentOrElse(onValue, onEmpty)
+ *   or(Supplier<Optional>)    - alternative Optional if empty
+ *   stream()                  - 0/1 element stream for flatMap-style chaining
+ */
+public class StreamAndOptionalImprovements {
+
+    public static void main(String[] args) {
+        System.out.println(Stream.of(1, 2, 3, 10, 4, 5)
+                .takeWhile(n -> n < 5).collect(Collectors.toList()));
+
+        System.out.println(Stream.of(1, 2, 3, 10, 4, 5)
+                .dropWhile(n -> n < 5).collect(Collectors.toList()));
+
+        System.out.println(Stream.ofNullable((String) null).count());
+        System.out.println(Stream.ofNullable("x").count());
+
+        System.out.println(Stream.iterate(1, n -> n < 100, n -> n * 2)
+                .collect(Collectors.toList()));
+
+        Optional<String> empty = Optional.empty();
+        empty.ifPresentOrElse(
+                v -> System.out.println("got " + v),
+                () -> System.out.println("nothing to see"));
+
+        String val = empty.or(() -> Optional.of("fallback")).orElseThrow();
+        System.out.println("val = " + val);
+
+        long count = Stream.of(Optional.of("a"), Optional.<String>empty(), Optional.of("c"))
+                .flatMap(Optional::stream)
+                .count();
+        System.out.println("non-empty count = " + count);
+    }
+}

--- a/java-features-reference/src/main/java/com/careerit/java/java10/VarLocalInference.java
+++ b/java-features-reference/src/main/java/com/careerit/java/java10/VarLocalInference.java
@@ -1,0 +1,48 @@
+package com.careerit.java.java10;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Java 10 - `var` local-variable type inference.
+ *
+ * `var` can be used for:
+ *   - local variables with initializer
+ *   - loop indexes in for / enhanced for
+ *   - indexes in try-with-resources
+ *
+ * `var` CANNOT be used for:
+ *   - method parameters, return types, fields
+ *   - without an initializer
+ *   - with `null` literal (type inference fails)
+ *   - lambda parameters (that is Java 11)
+ *
+ * Guideline: use `var` when the type is obvious from the RHS, or when the type
+ * is noisy but irrelevant (long generic types). Do not use it to hide types
+ * the reader needs.
+ */
+public class VarLocalInference {
+
+    public static void main(String[] args) {
+        var list = new ArrayList<String>();
+        list.add("one");
+        list.add("two");
+
+        var map = Map.of("a", 1, "b", 2);
+
+        for (var i = 0; i < list.size(); i++) {
+            System.out.println(i + " -> " + list.get(i));
+        }
+
+        for (var entry : map.entrySet()) {
+            System.out.println(entry.getKey() + "=" + entry.getValue());
+        }
+
+        var lengths = list.stream().mapToInt(String::length).toArray();
+        System.out.println("sum=" + java.util.Arrays.stream(lengths).sum());
+
+        List<String> typedList = list;
+        System.out.println(typedList);
+    }
+}

--- a/java-features-reference/src/main/java/com/careerit/java/java11/FilesReadWriteString.java
+++ b/java-features-reference/src/main/java/com/careerit/java/java11/FilesReadWriteString.java
@@ -1,0 +1,22 @@
+package com.careerit.java.java11;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/**
+ * Java 11 - Files.readString / Files.writeString.
+ *
+ * Before Java 11 you had to read all bytes and wrap them in `new String(...)`
+ * with an explicit charset. These methods default to UTF-8.
+ */
+public class FilesReadWriteString {
+
+    public static void main(String[] args) throws IOException {
+        Path tmp = Files.createTempFile("java11-demo-", ".txt");
+        Files.writeString(tmp, "hello from Java 11\nline two\n");
+        String content = Files.readString(tmp);
+        System.out.println("content =\n" + content);
+        Files.deleteIfExists(tmp);
+    }
+}

--- a/java-features-reference/src/main/java/com/careerit/java/java11/HttpClientDemo.java
+++ b/java-features-reference/src/main/java/com/careerit/java/java11/HttpClientDemo.java
@@ -1,0 +1,46 @@
+package com.careerit.java.java11;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Java 11 - standard HttpClient (JEP 321).
+ *
+ * Replaces HttpURLConnection. Supports HTTP/1.1, HTTP/2, WebSocket,
+ * sync + async, and reactive streams for bodies.
+ *
+ * The sample requests are commented out to avoid hitting the network during
+ * offline builds; uncomment to try them.
+ */
+public class HttpClientDemo {
+
+    public static void main(String[] args) {
+        HttpClient client = HttpClient.newBuilder()
+                .version(HttpClient.Version.HTTP_2)
+                .connectTimeout(Duration.ofSeconds(5))
+                .build();
+
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create("https://example.com"))
+                .timeout(Duration.ofSeconds(5))
+                .GET()
+                .build();
+
+        System.out.println("HttpClient built: " + client.version());
+        System.out.println("Request URI: " + request.uri());
+
+        // Synchronous:
+        // HttpResponse<String> res = client.send(request, HttpResponse.BodyHandlers.ofString());
+        // System.out.println("status=" + res.statusCode() + ", body chars=" + res.body().length());
+
+        // Asynchronous:
+        CompletableFuture<HttpResponse<String>> future =
+                client.sendAsync(request, HttpResponse.BodyHandlers.ofString());
+        // future.thenAccept(r -> System.out.println("async status=" + r.statusCode())).join();
+        System.out.println("async future created: " + (future != null));
+    }
+}

--- a/java-features-reference/src/main/java/com/careerit/java/java11/StringMethods.java
+++ b/java-features-reference/src/main/java/com/careerit/java/java11/StringMethods.java
@@ -1,0 +1,29 @@
+package com.careerit.java.java11;
+
+import java.util.stream.Collectors;
+
+/**
+ * Java 11 - String API additions.
+ *
+ *   isBlank()         : true if empty or only whitespace (Unicode-aware)
+ *   strip() / stripLeading() / stripTrailing() : Unicode-aware trim
+ *   lines()           : Stream<String> split by line terminators
+ *   repeat(n)         : repeat string n times
+ *   chars()           : IntStream of code units (inherited, but commonly used)
+ *
+ * trim() only strips US-ASCII whitespace; strip() follows Character.isWhitespace.
+ */
+public class StringMethods {
+
+    public static void main(String[] args) {
+        System.out.println("   ".isBlank());
+        System.out.println("  hello  ".strip());
+        System.out.println("abc".repeat(3));
+
+        String multi = "one\ntwo\nthree";
+        String joined = multi.lines()
+                .map(String::toUpperCase)
+                .collect(Collectors.joining(" | "));
+        System.out.println(joined);
+    }
+}

--- a/java-features-reference/src/main/java/com/careerit/java/java11/VarInLambda.java
+++ b/java-features-reference/src/main/java/com/careerit/java/java11/VarInLambda.java
@@ -1,0 +1,23 @@
+package com.careerit.java.java11;
+
+import java.util.List;
+
+/**
+ * Java 11 - `var` in lambda parameters.
+ *
+ * Main reason: you can attach annotations to lambda parameters.
+ * Rules:
+ *   - all parameters must use `var` (or all inferred without `var`) - no mixing
+ *   - parentheses are required, even for single parameter
+ */
+public class VarInLambda {
+
+    @interface NonNull {}
+
+    public static void main(String[] args) {
+        List<String> names = List.of("Ravi", "Asha");
+        names.forEach((var n) -> System.out.println(n));
+        names.stream().map((@NonNull var n) -> n.toUpperCase())
+                .forEach(System.out::println);
+    }
+}

--- a/java-features-reference/src/main/java/com/careerit/java/java12/CollectorsTeeing.java
+++ b/java-features-reference/src/main/java/com/careerit/java/java12/CollectorsTeeing.java
@@ -1,0 +1,30 @@
+package com.careerit.java.java12;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Java 12 - Collectors.teeing.
+ *
+ * Runs two downstream collectors in parallel and merges their results.
+ * Very handy for "compute X and Y in a single pass" problems.
+ */
+public class CollectorsTeeing {
+
+    public static void main(String[] args) {
+        List<Integer> nums = List.of(10, 20, 30, 40, 50);
+
+        double average = nums.stream().collect(Collectors.teeing(
+                Collectors.summingInt(Integer::intValue),
+                Collectors.counting(),
+                (sum, count) -> (double) sum / count));
+        System.out.println("average = " + average);
+
+        record MinMax(int min, int max) {}
+        MinMax range = nums.stream().collect(Collectors.teeing(
+                Collectors.minBy(Integer::compareTo),
+                Collectors.maxBy(Integer::compareTo),
+                (lo, hi) -> new MinMax(lo.orElseThrow(), hi.orElseThrow())));
+        System.out.println("range = " + range);
+    }
+}

--- a/java-features-reference/src/main/java/com/careerit/java/java12/SwitchExpressionsPreview.java
+++ b/java-features-reference/src/main/java/com/careerit/java/java12/SwitchExpressionsPreview.java
@@ -1,0 +1,34 @@
+package com.careerit.java.java12;
+
+/**
+ * Java 12 - Switch expressions (preview; became standard in Java 14).
+ *
+ * New form allows:
+ *   - arrow labels (case A -> ...) with no fall-through
+ *   - comma-separated case labels (case A, B ->)
+ *   - yielding a value (multi-line body uses `yield`)
+ *
+ * The file shows the final syntax (valid in Java 14+).
+ */
+public class SwitchExpressionsPreview {
+
+    enum Day { MON, TUE, WED, THU, FRI, SAT, SUN }
+
+    static int lettersInDay(Day d) {
+        return switch (d) {
+            case MON, FRI, SUN -> 6;
+            case TUE           -> 7;
+            case THU, SAT      -> {
+                int base = d.name().length();
+                yield base + 1;
+            }
+            case WED           -> 9;
+        };
+    }
+
+    public static void main(String[] args) {
+        for (Day d : Day.values()) {
+            System.out.println(d + " -> " + lettersInDay(d));
+        }
+    }
+}

--- a/java-features-reference/src/main/java/com/careerit/java/java13/TextBlocksPreview.java
+++ b/java-features-reference/src/main/java/com/careerit/java/java13/TextBlocksPreview.java
@@ -1,0 +1,40 @@
+package com.careerit.java.java13;
+
+/**
+ * Java 13 - Text blocks (preview; standard in Java 15).
+ *
+ * Use """...""" for multi-line string literals. Leading incidental whitespace
+ * is stripped based on the least-indented line. Trailing whitespace on each
+ * line is removed.
+ *
+ * Escape sequences introduced with text blocks:
+ *   \<newline>   : suppresses the line terminator (line continuation)
+ *   \s           : a single space that survives trailing-whitespace stripping
+ */
+public class TextBlocksPreview {
+
+    public static void main(String[] args) {
+        String json = """
+                {
+                  "name": "Ravi",
+                  "role": "engineer",
+                  "skills": ["java", "spring"]
+                }
+                """;
+        System.out.println(json);
+
+        String query = """
+                SELECT id, name, email
+                FROM   users
+                WHERE  active = true
+                ORDER  BY id
+                """;
+        System.out.println(query);
+
+        String continued = """
+                one \
+                line\
+                """;
+        System.out.println("continued = [" + continued + "]");
+    }
+}

--- a/java-features-reference/src/main/java/com/careerit/java/java14/HelpfulNpe.java
+++ b/java-features-reference/src/main/java/com/careerit/java/java14/HelpfulNpe.java
@@ -1,0 +1,29 @@
+package com.careerit.java.java14;
+
+/**
+ * Java 14 - Helpful NullPointerExceptions (JEP 358).
+ *
+ * When an NPE is thrown, the JVM adds a message that pinpoints which
+ * variable/field was null in a chained expression.
+ *
+ * Run with: java -XX:+ShowCodeDetailsInExceptionMessages ... (on by default in 15+)
+ *
+ * Example: a.b.c.d can now say
+ *   "Cannot invoke ... because the return value of 'A.b()' is null"
+ * instead of just "NullPointerException".
+ */
+public class HelpfulNpe {
+
+    record Address(String city) {}
+    record User(String name, Address address) {}
+
+    public static void main(String[] args) {
+        User u = new User("Ravi", null);
+        try {
+            int len = u.address().city().length();
+            System.out.println(len);
+        } catch (NullPointerException e) {
+            System.out.println("NPE: " + e.getMessage());
+        }
+    }
+}

--- a/java-features-reference/src/main/java/com/careerit/java/java14/PatternMatchingInstanceof.java
+++ b/java-features-reference/src/main/java/com/careerit/java/java14/PatternMatchingInstanceof.java
@@ -1,0 +1,35 @@
+package com.careerit.java.java14;
+
+/**
+ * Java 14 - Pattern matching for instanceof (preview; standard in Java 16).
+ *
+ * Old:
+ *   if (obj instanceof String) {
+ *       String s = (String) obj;
+ *       // use s
+ *   }
+ *
+ * New:
+ *   if (obj instanceof String s) {
+ *       // s is in scope, already cast
+ *   }
+ *
+ * The pattern variable is in scope wherever the compiler can prove the test
+ * matched (including the negation: `if (!(o instanceof String s)) return; use(s);`).
+ */
+public class PatternMatchingInstanceof {
+
+    static int lengthOrSize(Object obj) {
+        if (obj instanceof String s) return s.length();
+        if (obj instanceof java.util.Collection<?> c) return c.size();
+        if (obj instanceof int[] arr) return arr.length;
+        return -1;
+    }
+
+    public static void main(String[] args) {
+        System.out.println(lengthOrSize("hello"));
+        System.out.println(lengthOrSize(java.util.List.of(1, 2, 3)));
+        System.out.println(lengthOrSize(new int[]{1, 2}));
+        System.out.println(lengthOrSize(42));
+    }
+}

--- a/java-features-reference/src/main/java/com/careerit/java/java14/RecordsPreview.java
+++ b/java-features-reference/src/main/java/com/careerit/java/java14/RecordsPreview.java
@@ -1,0 +1,41 @@
+package com.careerit.java.java14;
+
+import java.util.List;
+
+/**
+ * Java 14 - Records (preview; standard in Java 16).
+ *
+ * A record is a transparent, immutable data carrier. The compiler generates:
+ *   - private final fields for each component
+ *   - a canonical constructor
+ *   - accessors named after each component
+ *   - equals/hashCode/toString based on components
+ *
+ * Records can have:
+ *   - compact constructors for validation / normalization
+ *   - additional static factories and instance methods
+ *   - static fields
+ * But NOT additional instance fields (all state must come from components).
+ *
+ * Records are implicitly final and extend java.lang.Record.
+ */
+public class RecordsPreview {
+
+    record Point(int x, int y) {
+        // compact constructor: validation, no parameter list
+        public Point {
+            if (x < 0 || y < 0) throw new IllegalArgumentException("non-negative only");
+        }
+        // extra behaviour is allowed
+        public Point translate(int dx, int dy) { return new Point(x + dx, y + dy); }
+        public static Point origin() { return new Point(0, 0); }
+    }
+
+    public static void main(String[] args) {
+        Point a = new Point(1, 2);
+        Point b = a.translate(10, 10);
+        System.out.println(a + " -> " + b);
+        System.out.println("equals? " + a.equals(new Point(1, 2)));
+        System.out.println(List.of(Point.origin(), a, b));
+    }
+}

--- a/java-features-reference/src/main/java/com/careerit/java/java15/SealedClassesPreview.java
+++ b/java-features-reference/src/main/java/com/careerit/java/java15/SealedClassesPreview.java
@@ -1,0 +1,32 @@
+package com.careerit.java.java15;
+
+/**
+ * Java 15 - Sealed classes/interfaces (preview; standard in Java 17).
+ *
+ * `sealed` restricts which classes/interfaces may extend or implement it.
+ * Permitted subtypes must be declared with `final`, `sealed`, or `non-sealed`.
+ *
+ * Sealed + records = algebraic data types, and the compiler can verify
+ * exhaustiveness of switch expressions over the type hierarchy.
+ */
+public class SealedClassesPreview {
+
+    sealed interface Shape permits Circle, Square, Triangle {}
+    record Circle(double r) implements Shape {}
+    record Square(double side) implements Shape {}
+    record Triangle(double base, double height) implements Shape {}
+
+    static double area(Shape s) {
+        return switch (s) {
+            case Circle c      -> Math.PI * c.r() * c.r();
+            case Square sq     -> sq.side() * sq.side();
+            case Triangle t    -> 0.5 * t.base() * t.height();
+        };
+    }
+
+    public static void main(String[] args) {
+        System.out.println(area(new Circle(2)));
+        System.out.println(area(new Square(3)));
+        System.out.println(area(new Triangle(4, 5)));
+    }
+}

--- a/java-features-reference/src/main/java/com/careerit/java/java15/TextBlocksFinal.java
+++ b/java-features-reference/src/main/java/com/careerit/java/java15/TextBlocksFinal.java
@@ -1,0 +1,27 @@
+package com.careerit.java.java15;
+
+/**
+ * Java 15 - Text blocks are now a permanent feature.
+ *
+ * Common uses: SQL, JSON, HTML, log messages.
+ */
+public class TextBlocksFinal {
+
+    public static void main(String[] args) {
+        String html = """
+                <html>
+                  <body>
+                    <h1>Hello, %s</h1>
+                  </body>
+                </html>
+                """.formatted("World");
+        System.out.println(html);
+
+        // `\s` keeps the space (trailing whitespace would normally be stripped).
+        String padded = """
+                col1  col2\s
+                a     b\s
+                """;
+        System.out.println("[" + padded + "]");
+    }
+}

--- a/java-features-reference/src/main/java/com/careerit/java/java16/RecordsFinalized.java
+++ b/java-features-reference/src/main/java/com/careerit/java/java16/RecordsFinalized.java
@@ -3,18 +3,51 @@ package com.careerit.java.java16;
 import java.util.List;
 
 /**
- * Java 16 - Records become a permanent feature (JEP 395).
+ * ============================================================================
+ *  Java 16 : RECORDS (permanent - JEP 395)
+ * ============================================================================
  *
- * Also in Java 16: pattern matching for instanceof is final, Stream.toList()
- * is added, and local records/enums/interfaces are allowed inside methods.
+ *  WHAT THE COMPILER GENERATES FROM  `record Point(int x, int y) {}`
+ *  ----------------------------------------------------------------
+ *   - private final int x;  private final int y;
+ *   - public Point(int x, int y) { this.x = x; this.y = y; }   // canonical ctor
+ *   - public int x() { return x; }                              // accessor
+ *   - public int y() { return y; }
+ *   - public boolean equals(Object)  : field-by-field
+ *   - public int hashCode()          : based on fields
+ *   - public String toString()       : "Point[x=.., y=..]"
+ *
+ *  RULES
+ *  -----
+ *   - records are implicitly FINAL (can't be extended)
+ *   - cannot declare additional INSTANCE fields (state must come from components)
+ *   - CAN declare static fields, static methods, instance methods
+ *   - CAN declare compact / canonical constructors for validation
+ *   - CAN implement interfaces
+ *
+ *  USE CASES
+ *  ---------
+ *   * DTOs / value objects
+ *   * method return tuples (e.g. "record Result(int count, double avg){}")
+ *   * algebraic data types (combine with sealed)
+ *   * local records inside methods - great for grouping intermediate data
+ *     in a single pipeline stage
+ * ============================================================================
  */
 public class RecordsFinalized {
 
+    // ----------------------------------------------------------------
+    // 1. Basic record with validation (compact constructor)
+    // ----------------------------------------------------------------
     record Money(long amount, String currency) {
+        // Compact constructor: no parameter list, validates / normalizes.
         public Money {
-            if (amount < 0) throw new IllegalArgumentException("negative");
-            currency = currency.toUpperCase();
+            if (amount < 0) throw new IllegalArgumentException("negative amount");
+            if (currency == null || currency.isBlank())
+                throw new IllegalArgumentException("currency required");
+            currency = currency.toUpperCase();   // normalize - assignment is allowed here
         }
+
         public Money add(Money other) {
             if (!currency.equals(other.currency))
                 throw new IllegalArgumentException("mismatched currency");
@@ -22,8 +55,50 @@ public class RecordsFinalized {
         }
     }
 
+    // ----------------------------------------------------------------
+    // 2. Record with extra behaviour + static factory + constants
+    // ----------------------------------------------------------------
+    record Range(int low, int high) {
+        public Range {
+            if (low > high) throw new IllegalArgumentException("low > high");
+        }
+
+        public boolean contains(int v) { return v >= low && v <= high; }
+        public int width()             { return high - low; }
+
+        public static Range ofWidth(int low, int width) { return new Range(low, low + width); }
+        public static final Range PERCENT = new Range(0, 100);
+    }
+
+    // ----------------------------------------------------------------
+    // 3. Record implementing an interface
+    // ----------------------------------------------------------------
+    interface Named { String name(); }
+    record Student(String name, int score) implements Named {
+        public boolean passed() { return score >= 40; }
+    }
+
+    // ----------------------------------------------------------------
+    // 4. Overriding an accessor (rare, but legal)
+    //    Useful when you want a defensive copy.
+    // ----------------------------------------------------------------
+    record Wrap(int[] data) {
+        @Override
+        public int[] data() {
+            return data.clone();   // defensive copy out
+        }
+    }
+
+    // ----------------------------------------------------------------
+    // 5. Generic record
+    // ----------------------------------------------------------------
+    record Pair<A, B>(A first, B second) {
+        public <A2> Pair<A2, B> withFirst(A2 a) { return new Pair<>(a, second); }
+    }
+
     public static void main(String[] args) {
-        // Local record inside a method (allowed since Java 16).
+
+        // Local record: allowed since Java 16. Perfect for pipeline intermediates.
         record Sale(String item, Money price) {}
 
         List<Sale> sales = List.of(
@@ -34,6 +109,36 @@ public class RecordsFinalized {
         Money total = sales.stream()
                 .map(Sale::price)
                 .reduce(new Money(0, "INR"), Money::add);
-        System.out.println("total = " + total);
+        System.out.println("[1] total = " + total);
+
+        // Validation kicks in on construction.
+        try {
+            new Money(-10, "INR");
+        } catch (IllegalArgumentException ex) {
+            System.out.println("[1] validation ok: " + ex.getMessage());
+        }
+
+        // Range demo
+        System.out.println("[2] percent contains 50? " + Range.PERCENT.contains(50));
+        System.out.println("[2] ofWidth(10,5) = " + Range.ofWidth(10, 5));
+
+        // Student demo
+        Student s = new Student("Ravi", 72);
+        System.out.println("[3] " + s + " passed=" + s.passed());
+
+        // Defensive copy
+        int[] raw = {1, 2, 3};
+        Wrap w = new Wrap(raw);
+        w.data()[0] = 99;   // mutating the returned clone does NOT change the record
+        System.out.println("[4] data[0] = " + w.data()[0]);
+
+        // Generic pair
+        Pair<String, Integer> p = new Pair<>("age", 30);
+        System.out.println("[5] pair = " + p + ", withFirst = " + p.withFirst(42));
+
+        // equals / hashCode are component-based - free for free.
+        Money a = new Money(100, "INR");
+        Money b = new Money(100, "inr");  // normalized to INR in compact ctor
+        System.out.println("[equals] " + a.equals(b) + " hash=" + (a.hashCode() == b.hashCode()));
     }
 }

--- a/java-features-reference/src/main/java/com/careerit/java/java16/RecordsFinalized.java
+++ b/java-features-reference/src/main/java/com/careerit/java/java16/RecordsFinalized.java
@@ -1,0 +1,39 @@
+package com.careerit.java.java16;
+
+import java.util.List;
+
+/**
+ * Java 16 - Records become a permanent feature (JEP 395).
+ *
+ * Also in Java 16: pattern matching for instanceof is final, Stream.toList()
+ * is added, and local records/enums/interfaces are allowed inside methods.
+ */
+public class RecordsFinalized {
+
+    record Money(long amount, String currency) {
+        public Money {
+            if (amount < 0) throw new IllegalArgumentException("negative");
+            currency = currency.toUpperCase();
+        }
+        public Money add(Money other) {
+            if (!currency.equals(other.currency))
+                throw new IllegalArgumentException("mismatched currency");
+            return new Money(amount + other.amount, currency);
+        }
+    }
+
+    public static void main(String[] args) {
+        // Local record inside a method (allowed since Java 16).
+        record Sale(String item, Money price) {}
+
+        List<Sale> sales = List.of(
+                new Sale("book",  new Money(500,  "inr")),
+                new Sale("pen",   new Money(100,  "inr")),
+                new Sale("mouse", new Money(1200, "inr")));
+
+        Money total = sales.stream()
+                .map(Sale::price)
+                .reduce(new Money(0, "INR"), Money::add);
+        System.out.println("total = " + total);
+    }
+}

--- a/java-features-reference/src/main/java/com/careerit/java/java16/StreamToList.java
+++ b/java-features-reference/src/main/java/com/careerit/java/java16/StreamToList.java
@@ -1,0 +1,26 @@
+package com.careerit.java.java16;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+/**
+ * Java 16 - Stream.toList().
+ *
+ * Shorter than `.collect(Collectors.toList())`. Returns an UNMODIFIABLE list
+ * and tolerates null elements (unlike List.copyOf / Collectors.toUnmodifiableList).
+ */
+public class StreamToList {
+
+    public static void main(String[] args) {
+        List<String> upper = Stream.of("a", "b", "c")
+                .map(String::toUpperCase)
+                .toList();
+        System.out.println(upper);
+
+        try {
+            upper.add("d");
+        } catch (UnsupportedOperationException e) {
+            System.out.println("unmodifiable confirmed");
+        }
+    }
+}

--- a/java-features-reference/src/main/java/com/careerit/java/java17/PatternMatchingSwitchPreview.java
+++ b/java-features-reference/src/main/java/com/careerit/java/java17/PatternMatchingSwitchPreview.java
@@ -1,0 +1,38 @@
+package com.careerit.java.java17;
+
+/**
+ * Java 17 - Pattern matching for switch (preview; standard in Java 21).
+ *
+ * Adds:
+ *   - type patterns:       case Integer i ->
+ *   - guarded patterns:    case String s when !s.isEmpty() ->
+ *   - null case:           case null ->
+ *   - exhaustiveness check for sealed hierarchies
+ */
+public class PatternMatchingSwitchPreview {
+
+    sealed interface JsonValue permits JsonNull, JsonBool, JsonNumber, JsonString {}
+    record JsonNull()             implements JsonValue {}
+    record JsonBool(boolean b)    implements JsonValue {}
+    record JsonNumber(double n)   implements JsonValue {}
+    record JsonString(String s)   implements JsonValue {}
+
+    static String render(Object o) {
+        return switch (o) {
+            case null               -> "null";
+            case Integer i when i<0 -> "neg int " + i;
+            case Integer i          -> "int "     + i;
+            case String s           -> "str "     + s;
+            case JsonValue v        -> "json "    + v;
+            default                 -> "other";
+        };
+    }
+
+    public static void main(String[] args) {
+        System.out.println(render(null));
+        System.out.println(render(-5));
+        System.out.println(render(42));
+        System.out.println(render("hi"));
+        System.out.println(render(new JsonString("x")));
+    }
+}

--- a/java-features-reference/src/main/java/com/careerit/java/java17/RandomGenerators.java
+++ b/java-features-reference/src/main/java/com/careerit/java/java17/RandomGenerators.java
@@ -1,0 +1,24 @@
+package com.careerit.java.java17;
+
+import java.util.random.RandomGenerator;
+import java.util.random.RandomGeneratorFactory;
+
+/**
+ * Java 17 - Enhanced pseudo-random number generators (JEP 356).
+ *
+ * A unified interface RandomGenerator replaces the ad-hoc Random / SplittableRandom /
+ * ThreadLocalRandom APIs. You can pick an algorithm by name and get well-defined
+ * statistical properties.
+ */
+public class RandomGenerators {
+
+    public static void main(String[] args) {
+        RandomGenerator rng = RandomGeneratorFactory.of("L64X128MixRandom").create(42L);
+        rng.ints(5, 0, 100).forEach(i -> System.out.print(i + " "));
+        System.out.println();
+
+        RandomGeneratorFactory.all()
+                .limit(5)
+                .forEach(f -> System.out.println(f.name() + " period=" + f.period()));
+    }
+}

--- a/java-features-reference/src/main/java/com/careerit/java/java17/SealedFinal.java
+++ b/java-features-reference/src/main/java/com/careerit/java/java17/SealedFinal.java
@@ -1,31 +1,106 @@
 package com.careerit.java.java17;
 
 /**
- * Java 17 - Sealed classes are now a permanent feature (JEP 409).
+ * ============================================================================
+ *  Java 17 : SEALED CLASSES (permanent - JEP 409)
+ * ============================================================================
  *
- * Permitted types must be in the same module (or same package if the class is
- * in the unnamed module). Use `final`, `sealed`, or `non-sealed` on each
- * direct subtype to continue (or close) the hierarchy.
+ *  WHY SEALED?
+ *  -----------
+ *  Normal inheritance is open: anyone anywhere can extend your class.
+ *  `sealed` lets an author say "these are the ONLY allowed direct subtypes."
+ *  That enables:
+ *    - safe, exhaustive switch (no default needed)
+ *    - algebraic data types (records + sealed = ADTs)
+ *    - better modelling of closed hierarchies (Result = Ok | Err)
+ *
+ *  SYNTAX
+ *  ------
+ *   sealed interface Shape permits Circle, Square, Triangle { }
+ *
+ *  Every permitted subtype MUST be declared as exactly one of:
+ *    - final        : no further extension
+ *    - sealed       : continues the restriction with its own permits clause
+ *    - non-sealed   : opens the hierarchy back up from this point down
+ *
+ *  Permitted types must live in the same module (or same package for unnamed module).
+ * ============================================================================
  */
 public class SealedFinal {
 
+    // ---------------------------------------------------------------
+    // Example 1: records + sealed = algebraic data type (ADT)
+    // Exhaustive switch needs no default.
+    // ---------------------------------------------------------------
+    sealed interface Shape permits Circle, Square, Triangle {}
+    record Circle(double r)                    implements Shape {}
+    record Square(double side)                 implements Shape {}
+    record Triangle(double base, double height) implements Shape {}
+
+    static double area(Shape s) {
+        return switch (s) {
+            case Circle c   -> Math.PI * c.r() * c.r();
+            case Square sq  -> sq.side() * sq.side();
+            case Triangle t -> 0.5 * t.base() * t.height();
+            // No default - compiler verifies all subtypes are covered.
+        };
+    }
+
+    // ---------------------------------------------------------------
+    // Example 2: final / sealed / non-sealed working together
+    // ---------------------------------------------------------------
     sealed interface Vehicle permits Car, Truck, Bike {}
     final class Car implements Vehicle {}
-    non-sealed class Truck implements Vehicle {} // anyone may further extend Truck
-    sealed class Bike implements Vehicle permits ElectricBike {}
+    non-sealed class Truck implements Vehicle {}   // anyone may subclass Truck further
+    sealed class Bike implements Vehicle permits ElectricBike, PedalBike {}
     final class ElectricBike extends Bike {}
-
-    public static void main(String[] args) {
-        Vehicle v = new SealedFinal().new Car();
-        System.out.println("vehicle kind = " + describe(v));
-    }
+    final class PedalBike extends Bike {}
 
     static String describe(Vehicle v) {
         return switch (v) {
             case Car c          -> "car";
             case Truck t        -> "truck";
             case ElectricBike e -> "e-bike";
-            case Bike b         -> "bike"; // non-ElectricBike subclasses of Bike
+            case PedalBike p    -> "pedal-bike";
+            case Bike b         -> "bike";  // catches future subclasses of non-sealed? NO, Bike is sealed
         };
+    }
+
+    // ---------------------------------------------------------------
+    // Example 3: Result type - a tiny "Either" / "Result"
+    // Common ADT used for explicit success/failure without exceptions.
+    // ---------------------------------------------------------------
+    sealed interface Result<T> permits Ok, Err {}
+    record Ok<T>(T value)           implements Result<T> {}
+    record Err<T>(String message)   implements Result<T> {}
+
+    static Result<Integer> safeParse(String s) {
+        try {
+            return new Ok<>(Integer.parseInt(s));
+        } catch (NumberFormatException e) {
+            return new Err<>("invalid int: " + s);
+        }
+    }
+
+    static String describeResult(Result<Integer> r) {
+        return switch (r) {
+            case Ok<Integer> ok    -> "ok=" + ok.value();
+            case Err<Integer> err  -> "err=" + err.message();
+        };
+    }
+
+    public static void main(String[] args) {
+        System.out.println("[1] circle area  = " + area(new Circle(2)));
+        System.out.println("[1] square area  = " + area(new Square(3)));
+        System.out.println("[1] triangle area= " + area(new Triangle(4, 5)));
+
+        SealedFinal outer = new SealedFinal();
+        Vehicle v = outer.new Car();
+        System.out.println("[2] vehicle = " + describe(v));
+        v = outer.new ElectricBike();
+        System.out.println("[2] vehicle = " + describe(v));
+
+        System.out.println("[3] " + describeResult(safeParse("42")));
+        System.out.println("[3] " + describeResult(safeParse("oops")));
     }
 }

--- a/java-features-reference/src/main/java/com/careerit/java/java17/SealedFinal.java
+++ b/java-features-reference/src/main/java/com/careerit/java/java17/SealedFinal.java
@@ -1,0 +1,31 @@
+package com.careerit.java.java17;
+
+/**
+ * Java 17 - Sealed classes are now a permanent feature (JEP 409).
+ *
+ * Permitted types must be in the same module (or same package if the class is
+ * in the unnamed module). Use `final`, `sealed`, or `non-sealed` on each
+ * direct subtype to continue (or close) the hierarchy.
+ */
+public class SealedFinal {
+
+    sealed interface Vehicle permits Car, Truck, Bike {}
+    final class Car implements Vehicle {}
+    non-sealed class Truck implements Vehicle {} // anyone may further extend Truck
+    sealed class Bike implements Vehicle permits ElectricBike {}
+    final class ElectricBike extends Bike {}
+
+    public static void main(String[] args) {
+        Vehicle v = new SealedFinal().new Car();
+        System.out.println("vehicle kind = " + describe(v));
+    }
+
+    static String describe(Vehicle v) {
+        return switch (v) {
+            case Car c          -> "car";
+            case Truck t        -> "truck";
+            case ElectricBike e -> "e-bike";
+            case Bike b         -> "bike"; // non-ElectricBike subclasses of Bike
+        };
+    }
+}

--- a/java-features-reference/src/main/java/com/careerit/java/java18/Utf8ByDefault.java
+++ b/java-features-reference/src/main/java/com/careerit/java/java18/Utf8ByDefault.java
@@ -1,0 +1,21 @@
+package com.careerit.java.java18;
+
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Java 18 - UTF-8 by default (JEP 400).
+ *
+ * The default charset of the standard java.io/java.nio APIs is now UTF-8,
+ * regardless of OS locale. Use Charset.defaultCharset() to observe it.
+ * Override with -Dfile.encoding=... if absolutely necessary (not recommended).
+ *
+ * Related Java 18 items: Simple Web Server (`jwebserver`) and @snippet in Javadoc.
+ */
+public class Utf8ByDefault {
+
+    public static void main(String[] args) {
+        System.out.println("default charset = " + Charset.defaultCharset());
+        System.out.println("UTF-8 equals default? " + StandardCharsets.UTF_8.equals(Charset.defaultCharset()));
+    }
+}

--- a/java-features-reference/src/main/java/com/careerit/java/java19/RecordPatternsPreview.java
+++ b/java-features-reference/src/main/java/com/careerit/java/java19/RecordPatternsPreview.java
@@ -1,0 +1,33 @@
+package com.careerit.java.java19;
+
+/**
+ * Java 19 - Record patterns (preview; standard in Java 21).
+ *
+ * Deconstruct a record directly inside instanceof / switch:
+ *   case Point(int x, int y) -> ...
+ *
+ * Supports nesting: you can match on `Line(Point(var x1, var y1), Point(var x2, var y2))`.
+ */
+public class RecordPatternsPreview {
+
+    record Point(int x, int y) {}
+    record Line(Point from, Point to) {}
+
+    static String describe(Object o) {
+        return switch (o) {
+            case Point(int x, int y) when x == y            -> "diagonal point " + x;
+            case Point(int x, int y)                        -> "point " + x + "," + y;
+            case Line(Point(var x1, var y1), Point(var x2, var y2)) ->
+                    "line " + x1 + "," + y1 + " -> " + x2 + "," + y2;
+            case null                                        -> "null";
+            default                                          -> "other";
+        };
+    }
+
+    public static void main(String[] args) {
+        System.out.println(describe(new Point(3, 3)));
+        System.out.println(describe(new Point(1, 4)));
+        System.out.println(describe(new Line(new Point(0, 0), new Point(5, 5))));
+        System.out.println(describe(null));
+    }
+}

--- a/java-features-reference/src/main/java/com/careerit/java/java19/StructuredConcurrencyIncubator.java
+++ b/java-features-reference/src/main/java/com/careerit/java/java19/StructuredConcurrencyIncubator.java
@@ -1,0 +1,30 @@
+package com.careerit.java.java19;
+
+/**
+ * Java 19 - Structured Concurrency (incubator, JEP 428).
+ *
+ * StructuredTaskScope treats a group of concurrent tasks as a single unit of
+ * work. When the scope is closed, all still-running forks are cancelled.
+ * Combined with virtual threads, this makes "fan-out, gather, cancel on error"
+ * boringly easy.
+ *
+ * Sketch below (real API requires --enable-preview on Java 21+ with
+ * jdk.incubator.concurrent in Java 19/20):
+ *
+ *   try (var scope = new StructuredTaskScope.ShutdownOnFailure()) {
+ *       Future<String> user   = scope.fork(() -> fetchUser());
+ *       Future<Integer> order = scope.fork(() -> fetchOrderCount());
+ *       scope.join().throwIfFailed();
+ *       return new Dashboard(user.resultNow(), order.resultNow());
+ *   }
+ *
+ * Benefits:
+ *   - clear parent-child relationship in thread dumps
+ *   - deterministic cancellation
+ *   - replaces brittle Future + ExecutorService + manual shutdown patterns
+ */
+public class StructuredConcurrencyIncubator {
+    public static void main(String[] args) {
+        System.out.println("Java 19 reference notes - see source comments.");
+    }
+}

--- a/java-features-reference/src/main/java/com/careerit/java/java19/VirtualThreadsPreview.java
+++ b/java-features-reference/src/main/java/com/careerit/java/java19/VirtualThreadsPreview.java
@@ -1,0 +1,41 @@
+package com.careerit.java.java19;
+
+import java.time.Duration;
+import java.util.concurrent.Executors;
+import java.util.stream.IntStream;
+
+/**
+ * Java 19 - Virtual threads (preview; standard in Java 21).
+ *
+ * Virtual threads are lightweight threads scheduled on a small pool of carrier
+ * platform threads. Blocking a virtual thread unmounts it from its carrier, so
+ * you can have millions of them doing synchronous, blocking IO cheaply.
+ *
+ * Prefer:
+ *   Executors.newVirtualThreadPerTaskExecutor()
+ * or
+ *   Thread.ofVirtual().start(runnable)
+ *
+ * Pitfalls:
+ *   - before Java 24, synchronized blocks could pin the carrier; prefer
+ *     java.util.concurrent.Lock in that era.
+ *   - virtual threads are NOT faster for CPU-bound work.
+ */
+public class VirtualThreadsPreview {
+
+    public static void main(String[] args) throws Exception {
+        long start = System.currentTimeMillis();
+        try (var executor = Executors.newVirtualThreadPerTaskExecutor()) {
+            IntStream.range(0, 10_000).forEach(i -> executor.submit(() -> {
+                try { Thread.sleep(Duration.ofMillis(50)); }
+                catch (InterruptedException e) { Thread.currentThread().interrupt(); }
+                return i;
+            }));
+        }
+        System.out.println("done in " + (System.currentTimeMillis() - start) + "ms");
+
+        Thread t = Thread.ofVirtual().name("vt-demo").start(() ->
+                System.out.println("running on " + Thread.currentThread()));
+        t.join();
+    }
+}

--- a/java-features-reference/src/main/java/com/careerit/java/java20/ScopedValuesIncubator.java
+++ b/java-features-reference/src/main/java/com/careerit/java/java20/ScopedValuesIncubator.java
@@ -1,0 +1,21 @@
+package com.careerit.java.java20;
+
+/**
+ * Java 20 - Scoped Values (incubator, JEP 429) and Record Patterns (2nd preview).
+ *
+ * Java 20 is a non-LTS release; most of its headline items are continued previews:
+ *   JEP 432 - Record Patterns (2nd preview)
+ *   JEP 433 - Pattern Matching for switch (4th preview)
+ *   JEP 436 - Virtual Threads (2nd preview)
+ *   JEP 437 - Structured Concurrency (2nd incubator)
+ *   JEP 429 - Scoped Values (incubator)
+ *
+ * Since these are reaffirmations, see the Java 21 final-form files
+ * (VirtualThreadsFinal, SequencedCollections, PatternMatchingSwitchFinal,
+ * ScopedValuesPreview) for compiling examples.
+ */
+public class ScopedValuesIncubator {
+    public static void main(String[] args) {
+        System.out.println("Java 20 reference notes - see source comments.");
+    }
+}

--- a/java-features-reference/src/main/java/com/careerit/java/java21/PatternMatchingSwitchFinal.java
+++ b/java-features-reference/src/main/java/com/careerit/java/java21/PatternMatchingSwitchFinal.java
@@ -1,21 +1,47 @@
 package com.careerit.java.java21;
 
+import java.util.List;
+
 /**
- * Java 21 - Pattern matching for switch is permanent (JEP 441).
- * Record patterns are also permanent (JEP 440).
+ * ============================================================================
+ *  Java 21 : PATTERN MATCHING FOR SWITCH (permanent)   JEP 441
+ *           + RECORD PATTERNS (permanent)               JEP 440
+ * ============================================================================
  *
- * Highlights:
- *   - type patterns and record (deconstruction) patterns
- *   - guarded patterns with `when`
- *   - `case null` and `case null, default` combinations
- *   - exhaustive on sealed hierarchies (no default needed)
+ *  BEFORE (pre-Java 17 style)
+ *  --------------------------
+ *   if      (obj instanceof Login l)    { ... }
+ *   else if (obj instanceof Logout l)   { ... }
+ *   else if (obj instanceof Purchase p) { ... }
+ *
+ *  NOW
+ *  ---
+ *   return switch (obj) {
+ *       case Login(String user)               -> ...
+ *       case Logout(String user)              -> ...
+ *       case Purchase(String user, double a)  -> ...
+ *   };
+ *
+ *  KEY FEATURES
+ *  ------------
+ *   1. Type patterns:       case Integer i        -> ...
+ *   2. Record patterns:     case Point(int x,_)   -> ...
+ *   3. Guarded patterns:    case String s when s.length() > 3 -> ...
+ *   4. Null handling:       case null             -> ...
+ *                           case null, default    -> ... (combine)
+ *   5. Exhaustiveness:      over a sealed hierarchy, no default needed.
+ *   6. Nested deconstruction:  case Line(Point(var x1,_), Point(var x2,_)) -> ...
+ * ============================================================================
  */
 public class PatternMatchingSwitchFinal {
 
+    // ---------------------------------------------------------------
+    // Demo 1: sealed + records + exhaustive switch
+    // ---------------------------------------------------------------
     sealed interface Event permits Login, Logout, Purchase {}
-    record Login(String user)              implements Event {}
-    record Logout(String user)             implements Event {}
-    record Purchase(String user, double amount) implements Event {}
+    record Login(String user)                    implements Event {}
+    record Logout(String user)                   implements Event {}
+    record Purchase(String user, double amount)  implements Event {}
 
     static String summarize(Event e) {
         return switch (e) {
@@ -26,10 +52,70 @@ public class PatternMatchingSwitchFinal {
         };
     }
 
+    // ---------------------------------------------------------------
+    // Demo 2: type patterns with guards + null handling
+    // ---------------------------------------------------------------
+    static String describe(Object o) {
+        return switch (o) {
+            case null               -> "null";
+            case Integer i when i<0 -> "negative int " + i;
+            case Integer i          -> "int " + i;
+            case String s when s.isBlank() -> "blank string";
+            case String s           -> "string: " + s;
+            case int[] arr          -> "int[] of length " + arr.length;
+            case List<?> l          -> "list size " + l.size();
+            default                 -> "other: " + o.getClass().getSimpleName();
+        };
+    }
+
+    // ---------------------------------------------------------------
+    // Demo 3: nested record deconstruction
+    // ---------------------------------------------------------------
+    record Point(int x, int y) {}
+    record Line(Point from, Point to) {}
+
+    static String classifyLine(Line l) {
+        return switch (l) {
+            case Line(Point(var x1, var y1), Point(var x2, var y2)) when x1 == x2 ->
+                    "vertical at x=" + x1;
+            case Line(Point(var x1, var y1), Point(var x2, var y2)) when y1 == y2 ->
+                    "horizontal at y=" + y1;
+            case Line(Point(var x1, var y1), Point(var x2, var y2)) ->
+                    "diagonal " + x1 + "," + y1 + " -> " + x2 + "," + y2;
+        };
+    }
+
+    // ---------------------------------------------------------------
+    // Demo 4: traditional "statement-style" switch with patterns
+    // ---------------------------------------------------------------
+    static void handle(Event e) {
+        switch (e) {
+            case Login l    -> System.out.println("welcome " + l.user());
+            case Logout l   -> System.out.println("bye "     + l.user());
+            case Purchase p -> System.out.println("charge $" + p.amount() + " to " + p.user());
+        }
+    }
+
     public static void main(String[] args) {
-        System.out.println(summarize(new Login("ravi")));
-        System.out.println(summarize(new Purchase("asha", 250)));
-        System.out.println(summarize(new Purchase("kiran", 5000)));
-        System.out.println(summarize(new Logout("ravi")));
+        System.out.println("[1] " + summarize(new Login("ravi")));
+        System.out.println("[1] " + summarize(new Purchase("asha", 250)));
+        System.out.println("[1] " + summarize(new Purchase("kiran", 5000)));
+
+        System.out.println("[2] " + describe(null));
+        System.out.println("[2] " + describe(-5));
+        System.out.println("[2] " + describe(42));
+        System.out.println("[2] " + describe(""));
+        System.out.println("[2] " + describe("hi"));
+        System.out.println("[2] " + describe(new int[]{1,2,3}));
+        System.out.println("[2] " + describe(List.of(1,2,3,4)));
+        System.out.println("[2] " + describe(3.14));
+
+        System.out.println("[3] " + classifyLine(new Line(new Point(0,0), new Point(0,5))));
+        System.out.println("[3] " + classifyLine(new Line(new Point(0,0), new Point(5,0))));
+        System.out.println("[3] " + classifyLine(new Line(new Point(0,0), new Point(3,4))));
+
+        handle(new Login("demo"));
+        handle(new Purchase("demo", 42));
+        handle(new Logout("demo"));
     }
 }

--- a/java-features-reference/src/main/java/com/careerit/java/java21/PatternMatchingSwitchFinal.java
+++ b/java-features-reference/src/main/java/com/careerit/java/java21/PatternMatchingSwitchFinal.java
@@ -1,0 +1,35 @@
+package com.careerit.java.java21;
+
+/**
+ * Java 21 - Pattern matching for switch is permanent (JEP 441).
+ * Record patterns are also permanent (JEP 440).
+ *
+ * Highlights:
+ *   - type patterns and record (deconstruction) patterns
+ *   - guarded patterns with `when`
+ *   - `case null` and `case null, default` combinations
+ *   - exhaustive on sealed hierarchies (no default needed)
+ */
+public class PatternMatchingSwitchFinal {
+
+    sealed interface Event permits Login, Logout, Purchase {}
+    record Login(String user)              implements Event {}
+    record Logout(String user)             implements Event {}
+    record Purchase(String user, double amount) implements Event {}
+
+    static String summarize(Event e) {
+        return switch (e) {
+            case Login(String u)                     -> "login("  + u + ")";
+            case Logout(String u)                    -> "logout(" + u + ")";
+            case Purchase(String u, double a) when a > 1000 -> "big-sale(" + u + ", " + a + ")";
+            case Purchase(String u, double a)        -> "sale("   + u + ", " + a + ")";
+        };
+    }
+
+    public static void main(String[] args) {
+        System.out.println(summarize(new Login("ravi")));
+        System.out.println(summarize(new Purchase("asha", 250)));
+        System.out.println(summarize(new Purchase("kiran", 5000)));
+        System.out.println(summarize(new Logout("ravi")));
+    }
+}

--- a/java-features-reference/src/main/java/com/careerit/java/java21/ScopedValuesPreview.java
+++ b/java-features-reference/src/main/java/com/careerit/java/java21/ScopedValuesPreview.java
@@ -1,0 +1,39 @@
+package com.careerit.java.java21;
+
+/**
+ * Java 21 - Scoped Values (preview, JEP 446).
+ *
+ * Scoped values are an immutable, one-way alternative to ThreadLocal that
+ * pair well with virtual threads + structured concurrency. A value is set for
+ * the dynamic extent of a `ScopedValue.where(KEY, value).run(() -> {...})`
+ * call; inside that block (and any thread it starts via StructuredTaskScope)
+ * the value is visible; outside it, the binding is gone.
+ *
+ * Why not ThreadLocal?
+ *   - mutable, pollutes worker threads in pools
+ *   - expensive inheritance on many child threads
+ *   - no clear "scope" — prone to leaks
+ *
+ * NOTE: API is `java.lang.ScopedValue`; still preview/incubating through 24.
+ * Sketch below; actual API requires --enable-preview.
+ */
+public class ScopedValuesPreview {
+
+    /*
+      static final ScopedValue<String> USER = ScopedValue.newInstance();
+
+      public static void main(String[] args) {
+          ScopedValue.where(USER, "ravi").run(() -> {
+              handleRequest();
+          });
+      }
+
+      static void handleRequest() {
+          System.out.println("handling as " + USER.get());
+      }
+    */
+
+    public static void main(String[] args) {
+        System.out.println("See source comments - ScopedValue requires preview flags.");
+    }
+}

--- a/java-features-reference/src/main/java/com/careerit/java/java21/SequencedCollections.java
+++ b/java-features-reference/src/main/java/com/careerit/java/java21/SequencedCollections.java
@@ -1,0 +1,41 @@
+package com.careerit.java.java21;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.SequencedCollection;
+import java.util.SequencedMap;
+import java.util.SequencedSet;
+
+/**
+ * Java 21 - Sequenced Collections (JEP 431).
+ *
+ * Three new interfaces unify the "has an order" concept:
+ *   SequencedCollection<E> adds: addFirst / addLast / getFirst / getLast /
+ *                                removeFirst / removeLast / reversed()
+ *   SequencedSet<E>         extends it
+ *   SequencedMap<K,V>       adds: firstEntry / lastEntry / putFirst / putLast /
+ *                                  pollFirstEntry / pollLastEntry / reversed / sequencedKeySet / ...
+ *
+ * Existing types retrofit them: List, Deque, LinkedHashSet, LinkedHashMap, TreeSet, TreeMap.
+ */
+public class SequencedCollections {
+
+    public static void main(String[] args) {
+        SequencedCollection<String> list = new ArrayList<>(List.of("b", "c"));
+        list.addFirst("a");
+        list.addLast("d");
+        System.out.println("list = " + list);
+        System.out.println("first=" + list.getFirst() + " last=" + list.getLast());
+        System.out.println("reversed = " + list.reversed());
+
+        SequencedSet<String> set = new LinkedHashSet<>();
+        set.add("y"); set.add("x"); set.addFirst("z");
+        System.out.println("set = " + set + " reversed=" + set.reversed());
+
+        SequencedMap<String, Integer> map = new LinkedHashMap<>();
+        map.put("one", 1); map.put("two", 2); map.putFirst("zero", 0);
+        System.out.println("map = " + map + " first=" + map.firstEntry() + " last=" + map.lastEntry());
+    }
+}

--- a/java-features-reference/src/main/java/com/careerit/java/java21/StringTemplatesPreview.java
+++ b/java-features-reference/src/main/java/com/careerit/java/java21/StringTemplatesPreview.java
@@ -1,0 +1,37 @@
+package com.careerit.java.java21;
+
+/**
+ * Java 21 - String Templates (preview, JEP 430).
+ *
+ * Syntax (preview): STR."Hello \{name}"
+ * They let you embed expressions in string literals with a processor that
+ * controls how the result is built. Examples:
+ *   STR            : simple interpolation to String
+ *   FMT (java.util.FormatProcessor) : printf-style formatting
+ *
+ * NOTE: This feature was withdrawn for redesign after Java 21/22. Because the
+ * syntax uses a preview feature, code is shown here as a reference block inside
+ * comments; the class is a placeholder so the module compiles under any JDK.
+ */
+public class StringTemplatesPreview {
+
+    /*
+      // Preview syntax (needs --enable-preview on Java 21/22):
+
+      String name = "Ravi";
+      int score   = 92;
+
+      String greet = STR."Hello \{name}, your score is \{score}";
+      // -> "Hello Ravi, your score is 92"
+
+      String line  = FMT."[\{name}%10s] %03d\{score}";
+      // printf-style formatting via the FMT processor
+    */
+
+    public static void main(String[] args) {
+        String name = "Ravi";
+        int score = 92;
+        String greet = "Hello " + name + ", your score is " + score;
+        System.out.println(greet + "  // (STR.\"...\" in Java 21 preview)");
+    }
+}

--- a/java-features-reference/src/main/java/com/careerit/java/java21/UnnamedPatternsPreview.java
+++ b/java-features-reference/src/main/java/com/careerit/java/java21/UnnamedPatternsPreview.java
@@ -1,0 +1,40 @@
+package com.careerit.java.java21;
+
+/**
+ * Java 21 - Unnamed patterns and variables (preview, JEP 443; standard in Java 22).
+ *
+ * Use `_` when a name is required by syntax but you don't care about the value.
+ *
+ * Locations:
+ *   - record deconstruction:   case Point(_, int y) ->
+ *   - pattern bindings:         case String _ ->
+ *   - catch clauses:            catch (IOException _) -> ...
+ *   - lambda parameters:        (x, _) -> x
+ *   - for-each:                 for (var _ : list) { count++; }
+ *
+ * Sketch shown - real syntax requires --enable-preview on Java 21.
+ */
+public class UnnamedPatternsPreview {
+
+    record Point(int x, int y) {}
+
+    /*
+      static int sumX(List<Point> pts) {
+          int s = 0;
+          for (Point(int x, _) : pts) s += x;   // ignoring y
+          return s;
+      }
+
+      static String describe(Object o) {
+          return switch (o) {
+              case Integer _ -> "int";
+              case String  _ -> "string";
+              default        -> "other";
+          };
+      }
+    */
+
+    public static void main(String[] args) {
+        System.out.println("See source comments - unnamed patterns require preview flags.");
+    }
+}

--- a/java-features-reference/src/main/java/com/careerit/java/java21/VirtualThreadsFinal.java
+++ b/java-features-reference/src/main/java/com/careerit/java/java21/VirtualThreadsFinal.java
@@ -1,0 +1,38 @@
+package com.careerit.java.java21;
+
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.Executors;
+
+/**
+ * Java 21 - Virtual threads are a permanent feature (JEP 444).
+ *
+ * Key idioms:
+ *   Thread.startVirtualThread(runnable)
+ *   Executors.newVirtualThreadPerTaskExecutor()
+ *   Thread.ofVirtual().name("x").start(runnable)
+ *
+ * Use virtual threads for IO-bound work where you'd otherwise size a huge
+ * platform-thread pool. Don't pool virtual threads - they are the pool.
+ */
+public class VirtualThreadsFinal {
+
+    public static void main(String[] args) throws Exception {
+        try (var ex = Executors.newVirtualThreadPerTaskExecutor()) {
+            List<Callable<String>> tasks = List.of(
+                    () -> fetch("https://example.com/a"),
+                    () -> fetch("https://example.com/b"),
+                    () -> fetch("https://example.com/c"));
+            List<String> results = ex.invokeAll(tasks)
+                    .stream()
+                    .map(f -> { try { return f.get(); } catch (Exception e) { return "err"; } })
+                    .toList();
+            System.out.println(results);
+        }
+    }
+
+    static String fetch(String url) throws InterruptedException {
+        Thread.sleep(50);
+        return url + " [ok on " + Thread.currentThread() + "]";
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,7 @@
         <module>spring-jdbc</module>
         <module>learning-spring-boot</module>
         <module>java-srping-jpa</module>
+        <module>java-features-reference</module>
     </modules>
 
     <properties>


### PR DESCRIPTION
New Maven module with runnable examples and interview notes for every Java
version from 8 (LTS) through 25 (LTS). Each Java version has its own package
containing small self-contained classes:

- Java 8: lambdas, functional interfaces, streams, collectors, Optional,
  method references, default/static interface methods, java.time,
  CompletableFuture
- Java 9: immutable collection factories, Stream/Optional additions,
  private interface methods
- Java 10-11: var, String methods, HttpClient, Files.readString/writeString
- Java 12-14: switch expressions, text blocks, records, pattern matching
  for instanceof, helpful NPE
- Java 15-17: sealed classes, Stream.toList, switch pattern matching preview,
  enhanced RNG
- Java 18-21: UTF-8 default, virtual threads, sequenced collections, record
  patterns, string templates, scoped values, unnamed patterns
- Java 22-25: reference notes for future features (FFM, stream gatherers,
  module imports, primitive patterns, flexible constructor bodies, compact
  source files)

Added README.md with a feature index and usage instructions.